### PR TITLE
BACKLOG-15619: Fix url context; fix visibility when mixin disabled

### DIFF
--- a/src/main/java/org/jahia/modules/sitemap/utils/VanityUrls.java
+++ b/src/main/java/org/jahia/modules/sitemap/utils/VanityUrls.java
@@ -58,7 +58,7 @@ public final class VanityUrls {
     }
 
     private static String getActiveUrl(List<VanityUrl> urls) {
-        Optional<VanityUrl> url = urls.stream().filter(v -> v.isActive()).findFirst();
+        Optional<VanityUrl> url = urls.stream().filter(v -> v.isDefaultMapping() && v.isActive()).findFirst();
         return (url.isPresent()) ? url.get().getUrl() : null;
     }
 

--- a/src/main/resources/common/sitemap-entry.jsp
+++ b/src/main/resources/common/sitemap-entry.jsp
@@ -13,7 +13,7 @@
     <c:set var="finalUrl" value="${ (not empty vanityUrl) ? vanityUrl : localeUrl }"/>
     <jcr:nodeProperty var="lastModified" node="${urlNode}" name="jcr:lastModified"/>
 
-    <loc>${url.server}<c:url value="${finalUrl}"/></loc>
+    <loc>${url.server}${finalUrl}</loc>
     <lastmod><fmt:formatDate value="${lastModified.date.time}" pattern="yyyy-MM-dd"/></lastmod>
 
     <c:set var="locales" value="${urlNode.getExistingLocales()}"/>

--- a/src/main/resources/jseont_sitemap/xml/sitemap.index.jsp
+++ b/src/main/resources/jseont_sitemap/xml/sitemap.index.jsp
@@ -19,6 +19,7 @@
 
 <c:set target="${renderContext}" property="contentType" value="text/xml;charset=UTF-8"/>
 
+<c:if test="${renderContext.site.isNodeType('jseomix:sitemap')}">
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
         <c:if test="${renderContext.liveMode and renderContext.site.defaultLanguage eq renderContext.mainResourceLocale.language}">
@@ -64,3 +65,4 @@
                 </c:forEach>
         </c:if>
 </sitemapindex>
+</c:if>

--- a/src/main/resources/jseont_sitemap/xml/sitemap.jsp
+++ b/src/main/resources/jseont_sitemap/xml/sitemap.jsp
@@ -11,11 +11,12 @@
 <%--@elvariable id="renderContext" type="org.jahia.services.render.RenderContext"--%>
 <%--@elvariable id="`url" type="org.jahia.services.render.URLGenerator"--%>
 
+<c:set var="entryNode" value="${renderContext.site}"/>
+
+<c:if test="${entryNode.isNodeType('jseomix:sitemap')}">
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="https://www.w3.org/1999/xhtml">
-
-    <c:set var="entryNode" value="${renderContext.site}"/>
 
     <%-- list of parent nodes to exclude --%>
     <jcr:sql var="excludeNodes"
@@ -44,3 +45,4 @@
     </c:forEach>
 
 </urlset>
+</c:if>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15619

## Description

* Fix jsp code to display correct URL (URL used twice in <c:url> tag)
* Show empty page when sitemap is disabled
* Fix logic for displaying vanity URLs. Checks for vanity urls that are both active and default to use. Otherwise, will use regular url.

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
