### PR TITLE
added stabilizing code to cypress

### DIFF
--- a/tests/cypress/page-object/digitall.home.page.ts
+++ b/tests/cypress/page-object/digitall.home.page.ts
@@ -11,7 +11,10 @@ class DigitallHomePage extends BasePage {
     }
 
     editPage(page: string) {
-        this.getIframeBody().contains('div', page).rightclick({ force: true })
+        this.getIframeBody()
+            .contains('div[role="row"]', page)
+            .rightclick({ force: true })
+            .should('have.class', 'context-menu-open')
         this.getIframeBody().contains('span', 'Edit').click()
         return editPage
     }

--- a/tests/cypress/page-object/edit.page.ts
+++ b/tests/cypress/page-object/edit.page.ts
@@ -3,14 +3,14 @@ import { BasePage } from './base.page'
 class EditPage extends BasePage {
     elements = {
         sitemap: "[id='jseomix:sitemap']",
-        sitemapspan: "[data-sel-role-dynamic-fieldset='jseomix:sitemap']",
+        // sitemapspan: "[data-sel-role-dynamic-fieldset='jseomix:sitemap']",
         save: "[data-sel-role='submitSave']",
         message: '#message-id',
     }
 
     clickOnSitemap() {
         cy.get(this.elements.sitemap).click()
-        cy.get(this.elements.sitemapspan).should('not.have.css', 'transform', 'translateX(14px)')
+        cy.get(this.elements.sitemap).should('be.checked')
         cy.get(this.elements.save).should('not.be.disabled')
         cy.get(this.elements.save).clickAttached()
         return this


### PR DESCRIPTION
the line `.should('have.class', 'context-menu-open')` makes sure that the correct page was right clicked. the action would repeat until the right page is selected.
the line `cy.get(this.elements.sitemap).should('be.checked')` works, because that element is a checkbox, and we have built-in functions to deal with checkboxes.
