### PR TITLE
Changed manifest order for Jahia provisioning

### DIFF
--- a/tests/warmup-manifest-build.yml
+++ b/tests/warmup-manifest-build.yml
@@ -1,8 +1,6 @@
 version: 1.0
 jobs:
-  - type: webproject
-    source: prepackaged
-    sitekey: digitall  
+ 
   - type: asset
     fetch: http
     username: NEXUS_USERNAME
@@ -15,6 +13,9 @@ jobs:
   - type: module
     id: sitemap
     filepath: /tmp/artifacts/sitemap-SNAPSHOT.jar
+  - type: webproject
+    source: prepackaged
+    sitekey: digitall    
   - type: modulesite
     action: enable
     moduleId: sitemap

--- a/tests/warmup-manifest-build.yml
+++ b/tests/warmup-manifest-build.yml
@@ -1,6 +1,5 @@
 version: 1.0
 jobs:
- 
   - type: asset
     fetch: http
     username: NEXUS_USERNAME

--- a/tests/warmup-manifest-snapshot.yml
+++ b/tests/warmup-manifest-snapshot.yml
@@ -1,8 +1,5 @@
 version: 1.0
 jobs:
-  - type: webproject
-    source: prepackaged
-    sitekey: digitall 
   - type: asset
     fetch: http
     username: NEXUS_USERNAME
@@ -21,6 +18,9 @@ jobs:
   - type: module
     id: sitemap
     filepath: /tmp/sitemap-LATEST.jar
+  - type: webproject
+    source: prepackaged
+    sitekey: digitall     
   - type: modulesite
     action: enable
     moduleId: sitemap


### PR DESCRIPTION
As we're debugging why the jobs are unstable, this pushed the action of installing a webproject later down the manifest execution
