### PR TITLE
BACKLOG-15713: Add file-based caching for sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The submission of your sitemap can be done automatically by a background job in 
 located at `${jahia.deploy.targetServerDirectory}/digital-factory-data/karaf/etc` called `org.jahia.modules.sitemap.config.impl.ConfigServiceImpl.cfg`.
 
     sitemap.job-frequency=24
+    # sitemap.cache-duration=4
     # Comma separated values
     sitemap.search-engines=http://www.google.com/webmasters/tools/ping?sitemap=
     # Comma separated values
@@ -38,12 +39,17 @@ located at `${jahia.deploy.targetServerDirectory}/digital-factory-data/karaf/etc
 
 At the moment, the configuration has 3 keys. 
 * Job Frequency
+* Cache Duration  
 * List of Search engines
 * List of sitemap urls
 
 ### Job frequency
 This value determines how often to send the sitemap url to the search engines. The base unit is in hours - thus a value of 24 means the 
 background job will run every 24 hours.
+
+### Cache duration
+This value determines how often to remove and refresh the file cache for sitemap.xml contents specified in hours. Cache expiration 
+defaults to 4 hours if no value is set.
 
 ### List of Search engines
 This is a comma-separated value of the list of search engines to use by the background job.

--- a/src/main/java/org/jahia/modules/sitemap/config/ConfigService.java
+++ b/src/main/java/org/jahia/modules/sitemap/config/ConfigService.java
@@ -34,9 +34,9 @@ public interface ConfigService {
 
     void setProperties(Map<String,String> properties);
     long getJobFrequency();
+    long getCacheDuration();
     List<String> getSearchEngines();
     List<String> getSitemapUrls();
     List<String> getIncludeContentTypes();
-
 
 }

--- a/src/main/java/org/jahia/modules/sitemap/config/impl/ConfigServiceImpl.java
+++ b/src/main/java/org/jahia/modules/sitemap/config/impl/ConfigServiceImpl.java
@@ -111,7 +111,8 @@ public class ConfigServiceImpl implements ConfigService {
     @Override public long getCacheDuration() {
         String configKey = String.format(PROP_FORMAT, SITEMAP_PARENT_PROPERTY, DOT, CACHE_DURATION);
         final String cacheDurationStr = properties.getOrDefault(configKey,"4"); // default 4 hour cache duration
-        return convertFromHour(Long.parseLong(cacheDurationStr));
+        long cacheDuration = Long.parseLong(cacheDurationStr);
+        return convertFromHour(Math.min(0, cacheDuration));
     }
 
     private long convertFromHour(long jobFrequency) {

--- a/src/main/java/org/jahia/modules/sitemap/config/impl/ConfigServiceImpl.java
+++ b/src/main/java/org/jahia/modules/sitemap/config/impl/ConfigServiceImpl.java
@@ -112,7 +112,7 @@ public class ConfigServiceImpl implements ConfigService {
         String configKey = String.format(PROP_FORMAT, SITEMAP_PARENT_PROPERTY, DOT, CACHE_DURATION);
         final String cacheDurationStr = properties.getOrDefault(configKey,"4"); // default 4 hour cache duration
         long cacheDuration = Long.parseLong(cacheDurationStr);
-        return convertFromHour(Math.min(0, cacheDuration));
+        return convertFromHour(Math.max(0, cacheDuration));
     }
 
     private long convertFromHour(long jobFrequency) {

--- a/src/main/java/org/jahia/modules/sitemap/config/impl/ConfigServiceImpl.java
+++ b/src/main/java/org/jahia/modules/sitemap/config/impl/ConfigServiceImpl.java
@@ -106,6 +106,14 @@ public class ConfigServiceImpl implements ConfigService {
         return new ArrayList<>(Arrays.asList(includedContentTypes.split(",")));
     }
 
+    /** @return sitemap file cache duration in ms
+     * @see org.jahia.modules.sitemap.filter.SitemapCacheFilter */
+    @Override public long getCacheDuration() {
+        String configKey = String.format(PROP_FORMAT, SITEMAP_PARENT_PROPERTY, DOT, CACHE_DURATION);
+        final String cacheDurationStr = properties.getOrDefault(configKey,"4"); // default 4 hour cache duration
+        return convertFromHour(Long.parseLong(cacheDurationStr));
+    }
+
     private long convertFromHour(long jobFrequency) {
         return TimeUnit.HOURS.toMillis(jobFrequency);
     }

--- a/src/main/java/org/jahia/modules/sitemap/constant/SitemapConstant.java
+++ b/src/main/java/org/jahia/modules/sitemap/constant/SitemapConstant.java
@@ -32,6 +32,7 @@ public final class SitemapConstant {
     public static final String SITEMAP_PARENT_PROPERTY="sitemap";
     public static final String DOT=".";
     public static final String JOB_FREQUENCY="job-frequency";
+    public static final String CACHE_DURATION="cache-duration";
     public static final String SEARCH_ENGINES="search-engines";
     public static final String SITEMAP_URLS = "sitemap-urls";
     public static final String INCLUDED_CONTENT_TYPES = "included-content-types";

--- a/src/main/java/org/jahia/modules/sitemap/filter/SitemapCacheFilter.java
+++ b/src/main/java/org/jahia/modules/sitemap/filter/SitemapCacheFilter.java
@@ -1,0 +1,173 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2021 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.sitemap.filter;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jahia.api.Constants;
+import org.jahia.modules.sitemap.utils.ConfigServiceUtils;
+import org.jahia.services.cache.CacheHelper;
+import org.jahia.services.content.JCRCallback;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.content.JCRSessionWrapper;
+import org.jahia.services.content.JCRTemplate;
+import org.jahia.services.render.RenderContext;
+import org.jahia.services.render.Resource;
+import org.jahia.services.render.filter.AbstractFilter;
+import org.jahia.services.render.filter.RenderChain;
+import org.jahia.services.render.filter.RenderFilter;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.RepositoryException;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Locale;
+
+/**
+ * Filter that creates sitemap file nodes for caching.
+ *
+ * Since it can be resource-intensive to go through and generate all sitemap entries,
+ * and since the built-in Jahia view caching isn't guaranteed (i.e. depending on traffic, less-used caches can get invalidated at any time)
+ * we've added a custom file-based caching layer to the sitemap.xml views that will be invalidated only after expiration has passed
+ * (currently set at 4 hours).
+ */
+@Component(service = RenderFilter.class)
+public class SitemapCacheFilter extends AbstractFilter {
+
+    private static final Logger logger = LoggerFactory.getLogger(SitemapCacheFilter.class);
+
+    private static final long EXPIRATION = ConfigServiceUtils.getCacheDuration();
+
+    /** Node name prefix for sitemap file caches */
+    private static final String CACHE_NAME = "sitemap-cache";
+
+    /** Session attribute flag to check in the sitemap views whether view needs to re-render or not */
+    private static final String RENDER_FLAG_ATTR = "refreshSitemapSession";
+
+
+    @Activate
+    public void activate() {
+        setPriority(15f);
+        setApplyOnNodeTypes("jseont:sitemapResource,jseont:sitemap");
+        setApplyOnModes("live");
+        setDescription("Filter for creating sitemap file nodes for caching");
+        logger.debug("Activated FileCacheFilter");
+    }
+
+    /**
+     * Check if view needs to be re-rendered or not and add a session flag that the view can then check to determine that logic.
+     * Also flush cache here if view needs to be re-rendered.
+     */
+    @Override public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
+        if (!needsCaching(resource)) return null;
+
+        JCRNodeWrapper cacheNode = getCacheNode(resource.getNode());
+        boolean refreshSitemap = (cacheNode == null) || isExpired(cacheNode);
+        renderContext.getRequest().getSession().setAttribute(RENDER_FLAG_ATTR, refreshSitemap);
+        if (refreshSitemap) { // manually flush jahia cache prior to render
+            CacheHelper.flushOutputCachesForPath(resource.getPath(), false);
+        }
+        return null;
+    }
+
+    @Override
+    public String execute(String previousOut, RenderContext renderContext, Resource resource, RenderChain chain)
+            throws RepositoryException
+    {
+        if (!needsCaching(resource)) return previousOut;
+
+        JCRNodeWrapper sitemapNode = resource.getNode();
+        boolean refreshSitemap = (Boolean) renderContext.getRequest().getSession().getAttribute(RENDER_FLAG_ATTR);
+        InputStream inputStream = null;
+        try {
+            if (refreshSitemap && StringUtils.isNotBlank(previousOut)) {
+                inputStream = IOUtils.toInputStream(previousOut, StandardCharsets.UTF_8);
+                refreshSitemapCache(sitemapNode, inputStream);
+                return previousOut;
+            } else {
+                JCRNodeWrapper cacheNode = getCacheNode(sitemapNode);
+                inputStream = cacheNode.getFileContent().downloadFile();
+                String out = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+                return out;
+            }
+        } catch (IOException e) {
+            logger.error("Unable to read sitemap file cache contents.");
+            renderContext.getResponse().setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return null;
+        } finally {
+            IOUtils.closeQuietly(inputStream);
+        }
+    }
+
+    /**
+     * Create or refresh file cache for given parent for a given locale
+     * Uses parent session to save
+     * https://stackoverflow.com/questions/4685959/get-file-out-of-jcr-file-node
+     */
+    private JCRNodeWrapper refreshSitemapCache(JCRNodeWrapper sitemapNode, InputStream data) throws RepositoryException {
+        String cacheName = getCacheName(sitemapNode);
+        String nodePath = sitemapNode.getPath();
+
+        // use system session to be able to save file cache in live workspace
+        return JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(null,
+                Constants.LIVE_WORKSPACE, null, new JCRCallback<JCRNodeWrapper>() {
+            @Override public JCRNodeWrapper doInJCR(JCRSessionWrapper session) throws RepositoryException {
+                JCRNodeWrapper node = session.getNode(nodePath);
+                node.uploadFile(cacheName, data, "application/xml");
+                session.save();
+                return node;
+            }
+        });
+    }
+
+
+    /** Apply file caching only for default template */
+    public boolean needsCaching(Resource resource) {
+        return "default".equalsIgnoreCase(resource.getTemplate());
+    }
+
+    public JCRNodeWrapper getCacheNode(JCRNodeWrapper node) throws RepositoryException {
+        if (node == null) return null;
+        String cacheName = getCacheName(node);
+        return (node.hasNode(cacheName)) ? node.getNode(cacheName) : null;
+    }
+
+    public String getCacheName(JCRNodeWrapper node) {
+        return CACHE_NAME + "-" + node.getLanguage();
+    }
+
+    private boolean isExpired(JCRNodeWrapper cacheNode) {
+        long exp = EXPIRATION;
+        Date lastModified = cacheNode.getContentLastModifiedAsDate();
+        long expirationInMs = lastModified.getTime() + exp;
+        return System.currentTimeMillis() > expirationInMs;
+    }
+
+}

--- a/src/main/java/org/jahia/modules/sitemap/job/SitemapBackgroundJob.java
+++ b/src/main/java/org/jahia/modules/sitemap/job/SitemapBackgroundJob.java
@@ -25,6 +25,7 @@ package org.jahia.modules.sitemap.job;
 
 import net.htmlparser.jericho.Source;
 import org.jahia.modules.sitemap.config.ConfigService;
+import org.jahia.modules.sitemap.utils.CacheUtils;
 import org.jahia.services.scheduler.BackgroundJob;
 import org.jahia.services.scheduler.SchedulerService;
 import org.jahia.settings.SettingsBean;
@@ -36,6 +37,7 @@ import org.quartz.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.jcr.RepositoryException;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -83,7 +85,7 @@ public class SitemapBackgroundJob extends BackgroundJob {
         }
     }
 
-    @Override public void executeJahiaJob(JobExecutionContext jobExecutionContext) {
+    @Override public void executeJahiaJob(JobExecutionContext jobExecutionContext) throws RepositoryException {
         final JobDataMap jobDataMap = jobExecutionContext.getJobDetail().getJobDataMap();
         final List<String> searchEngines = (List<String>) jobDataMap.get(SEARCH_ENGINES);
         final List<String> siteMaps = (List<String>) jobDataMap.get(SITEMAP_URLS);
@@ -95,7 +97,9 @@ public class SitemapBackgroundJob extends BackgroundJob {
         if (searchEngines.isEmpty()) {
             logger.warn("There are not entries found in the configuration: sitemap.search-engines");
         }
+
         if (!siteMaps.isEmpty() && !searchEngines.isEmpty()) {
+            CacheUtils.refreshSitemapCache(15*60000);
             for (String siteMap : siteMaps) {
                 for (String s : searchEngines) {
                     try {

--- a/src/main/java/org/jahia/modules/sitemap/utils/CacheUtils.java
+++ b/src/main/java/org/jahia/modules/sitemap/utils/CacheUtils.java
@@ -1,0 +1,100 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2021 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.sitemap.utils;
+
+import org.jahia.api.Constants;
+import org.jahia.services.content.JCRCallback;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.content.JCRSessionWrapper;
+import org.jahia.services.content.JCRTemplate;
+
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.query.QueryResult;
+import java.util.Date;
+
+/** Utility functions for sitemap cache */
+public class CacheUtils {
+
+    /** Node name prefix for sitemap file caches */
+    public static final String CACHE_NAME = "sitemap-cache";
+
+
+    public static boolean isExpired(JCRNodeWrapper cacheNode, long expiration) {
+        Date lastModified = cacheNode.getContentLastModifiedAsDate();
+        long expirationInMs = lastModified.getTime() + expiration;
+        return System.currentTimeMillis() > expirationInMs;
+    }
+
+    /**
+     * Delete all sitemap cache nodes that are older than expiration (in ms)
+     * @param expiration
+     * @throws RepositoryException
+     */
+    public static void refreshSitemapCache(long expiration) throws RepositoryException {
+
+        JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(null,
+                Constants.LIVE_WORKSPACE, null, new JCRCallback<Object>() {
+            @Override public Object doInJCR(JCRSessionWrapper session) throws RepositoryException {
+                QueryResult result = QueryHelper.getQuery(session, "SELECT * from [jseont:sitemap] WHERE ISDESCENDANTNODE('/sites')");
+                if (result == null) return null;
+
+                for (NodeIterator iter = result.getNodes(); iter.hasNext(); ) {
+                    JCRNodeWrapper sitemapNode = (JCRNodeWrapper) iter.nextNode();
+                    refreshExpiredCache(sitemapNode, expiration);
+
+                    // get all caches for sitemap resource
+                    String sitePath = sitemapNode.getParent().getPath();
+                    String query = "SELECT * from [jseont:sitemapResource] WHERE ISDESCENDANTNODE('%s')";
+                    QueryResult subResult = QueryHelper.getQuery(session, String.format(query, sitePath));
+                    if (subResult == null) continue;
+
+                    for (NodeIterator iter2 = subResult.getNodes(); iter2.hasNext(); ) {
+                        JCRNodeWrapper sitemapResourceNode = (JCRNodeWrapper) iter2.nextNode();
+                        refreshExpiredCache(sitemapResourceNode, expiration);
+                    }
+                }
+
+                session.save();
+                return null;
+            }
+        });
+    }
+
+    /** Delete all expired sitemap cache nodes for a given sitemap node */
+    private static void refreshExpiredCache(JCRNodeWrapper sitemapNode, long expiration) throws RepositoryException {
+        // safety check to make sure we're only dealing with sitemap nodes since we're dealing with delete operation
+        if (!sitemapNode.isNodeType("jseont:sitemap") && !sitemapNode.isNodeType("jseont:sitemapResource")) return;
+
+        // assumption: only file caches under the sitemap node
+        for (NodeIterator iter = sitemapNode.getNodes(); iter.hasNext(); ) {
+            JCRNodeWrapper cacheNode = (JCRNodeWrapper) iter.nextNode();
+            if (isExpired(cacheNode, expiration)) {
+                cacheNode.remove();
+            }
+        }
+    }
+
+
+}

--- a/src/main/java/org/jahia/modules/sitemap/utils/ConfigServiceUtils.java
+++ b/src/main/java/org/jahia/modules/sitemap/utils/ConfigServiceUtils.java
@@ -59,4 +59,8 @@ public final class ConfigServiceUtils {
                 .getServiceReference(ConfigService.class);
         return bundleContext.getService(serviceReference);
     }
+
+    public static long getCacheDuration() {
+        return getConfigService().getCacheDuration();
+    }
 }

--- a/src/main/java/org/jahia/modules/sitemap/utils/QueryHelper.java
+++ b/src/main/java/org/jahia/modules/sitemap/utils/QueryHelper.java
@@ -23,9 +23,8 @@
  */
 package org.jahia.modules.sitemap.utils;
 
-import org.jahia.services.content.JCRNodeWrapper;
-import org.jahia.services.content.JCRSessionFactory;
-import org.jahia.services.content.JCRSessionWrapper;
+import org.jahia.api.Constants;
+import org.jahia.services.content.*;
 import org.jahia.services.render.RenderContext;
 
 import javax.jcr.NodeIterator;
@@ -79,7 +78,7 @@ public final class QueryHelper {
         return result;
     }
 
-    private static QueryResult getQuery(JCRSessionWrapper session, String query) {
+    public static QueryResult getQuery(JCRSessionWrapper session, String query) {
         try {
             return session.getWorkspace().getQueryManager()
                     .createQuery(query, Query.JCR_SQL2).execute();

--- a/src/main/resources/META-INF/configuration/org.jahia.modules.sitemap.config.impl.ConfigServiceImpl.cfg
+++ b/src/main/resources/META-INF/configuration/org.jahia.modules.sitemap.config.impl.ConfigServiceImpl.cfg
@@ -1,4 +1,6 @@
 sitemap.job-frequency=24
+# sitemap.xml file cache refresh duration in hours; default to 4 hours if not specified
+# sitemap.cache-duration=4
 # Comma separated values
 sitemap.search-engines=http://www.google.com/webmasters/tools/ping?sitemap=
 # Comma separated values

--- a/src/main/resources/META-INF/definitions.cnd
+++ b/src/main/resources/META-INF/definitions.cnd
@@ -4,8 +4,10 @@
 <jmix = 'http://www.jahia.org/jahia/mix/1.0'>
 
 [jseont:sitemap] > jnt:content
+ + * (jnt:file)
 
 [jseont:sitemapResource] > jnt:content
+ + * (jnt:file)
 
 [jseomix:sitemap] mixin
  extends = jnt:virtualsite

--- a/src/main/resources/jseont_sitemap/xml/sitemap.jsp
+++ b/src/main/resources/jseont_sitemap/xml/sitemap.jsp
@@ -13,7 +13,8 @@
 
 <c:set var="entryNode" value="${renderContext.site}"/>
 
-<c:if test="${entryNode.isNodeType('jseomix:sitemap')}">
+<%-- node check type to make sure sitemap is not enabled then disabled --%>
+<c:if test="${entryNode.isNodeType('jseomix:sitemap') && refreshSitemapSession}">
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="https://www.w3.org/1999/xhtml">

--- a/src/main/resources/jseont_sitemap/xml/sitemap.jsp
+++ b/src/main/resources/jseont_sitemap/xml/sitemap.jsp
@@ -14,7 +14,7 @@
 <c:set var="entryNode" value="${renderContext.site}"/>
 
 <%-- node check type to make sure sitemap is not enabled then disabled --%>
-<c:if test="${entryNode.isNodeType('jseomix:sitemap') && refreshSitemapSession}">
+<c:if test="${entryNode.isNodeType('jseomix:sitemap')}">
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="https://www.w3.org/1999/xhtml">

--- a/src/main/resources/jseont_sitemapResource/xml/sitemapResource.jsp
+++ b/src/main/resources/jseont_sitemapResource/xml/sitemapResource.jsp
@@ -13,7 +13,7 @@
 
 <c:set var="entryNode" value="${currentNode.parent}"/>
 
-<c:if test="${entryNode.properties['createSitemap'].boolean && refreshSitemapSession}">
+<c:if test="${entryNode.properties['createSitemap'].boolean}">
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="https://www.w3.org/1999/xhtml">

--- a/src/main/resources/jseont_sitemapResource/xml/sitemapResource.jsp
+++ b/src/main/resources/jseont_sitemapResource/xml/sitemapResource.jsp
@@ -13,7 +13,7 @@
 
 <c:set var="entryNode" value="${currentNode.parent}"/>
 
-<c:if test="${entryNode.properties['createSitemap'].boolean}">
+<c:if test="${entryNode.properties['createSitemap'].boolean && refreshSitemapSession}">
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="https://www.w3.org/1999/xhtml">


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15713

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Add filter that handles file caching of sitemap.xml views:
  * create file nodes under sitemap node for each language if they do not exists
  * Update file caches if they are expired
* Add `sitemap-duration` property in config file. Defaults to 4 hour expiration if not defined.
* Add manual refresh of all sitemap caches for background job
