### PR TITLE
BACKLOG-15722: Fix-up an oversight on display on edit mode of the site.

### DIFF
--- a/src/main/resources/META-INF/definitions.cnd
+++ b/src/main/resources/META-INF/definitions.cnd
@@ -11,8 +11,8 @@
 
 [jseomix:sitemap] mixin
  extends = jnt:virtualsite
- - sitemapIndexURL (string) = '' autocreated
- - sitemapCacheDuration (string) = '' autocreated
+ - sitemapIndexURL (string) = '' hidden autocreated
+ - sitemapCacheDuration (string) = '' hidden autocreated
  + sitemap (jseont:sitemap) = jseont:sitemap mandatory autocreated
 
 [jseomix:sitemapResource] mixin


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-15722

## Description

Appreciated for @gflores-jahia for noticing this.
By adding the properties on the definitions it created the fields on the "EDIT" portion which is not intentional.