### PR TITLE
BACKLOG-15722: Fix-up the node type dependency to be nt:base. This will allow publish on creation.

### DIFF
--- a/src/main/resources/META-INF/definitions.cnd
+++ b/src/main/resources/META-INF/definitions.cnd
@@ -3,10 +3,10 @@
 <jnt = 'http://www.jahia.org/jahia/nt/1.0'>
 <jmix = 'http://www.jahia.org/jahia/mix/1.0'>
 
-[jseont:sitemap] > jnt:content
+[jseont:sitemap] > nt:base
  + * (jnt:file)
 
-[jseont:sitemapResource] > jnt:content
+[jseont:sitemapResource] > nt:base
  + * (jnt:file)
 
 [jseomix:sitemap] mixin


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-15722

## Description

Resolution to node autocreation issue not reflect on LIVE workspace.
Per note from @tdraier 
We should be using just the nt:base
As we should not extend jmix:publication (jmix:autopublish doesn't work with auto-created nodes) also remove the mix:versionable.
jnt:content is used as a base for content nodes (to be add/edit in page/folder)
