### PR TITLE
update orb version (fix id inconsistency creating 2 projects in sonar)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   docker: circleci/docker@0.5.20
   jq: circleci/jq@2.2.0
-  jahia-modules-orb: jahia/jahia-modules-orb@0.1.9
+  jahia-modules-orb: jahia/jahia-modules-orb@0.1.12
 
 # Parameters are available across the entire config file and can be used with this syntax: << pipeline.parameters.THE_PARAMETER >>
 # Avoid using project-specific variables in the jobs or steps.


### PR DESCRIPTION
Update jahia-modules-orb version to fix project-id inconsistency creating 2 projects in sonarqube