### PR TITLE
BACKLOG-16221: Flushing all caches.

### DIFF
--- a/src/main/java/org/jahia/modules/sitemap/graphql/api/GqlSitemapMutation.java
+++ b/src/main/java/org/jahia/modules/sitemap/graphql/api/GqlSitemapMutation.java
@@ -40,6 +40,7 @@ import org.jahia.modules.sitemap.services.SitemapService;
 
 import org.jahia.modules.sitemap.utils.CacheUtils;
 import org.jahia.modules.sitemap.utils.ConversionUtils;
+import org.jahia.services.cache.CacheHelper;
 
 public class GqlSitemapMutation {
 
@@ -68,6 +69,7 @@ public class GqlSitemapMutation {
         try {
             CacheUtils.refreshSitemapCache(ConversionUtils.longVal(expirationTimeDifference,
                     ConversionUtils.convertFromHour(4L)), siteKey);
+            CacheUtils.flushJntPages(siteKey); // Flushing specific jnt pages
             return true;
         } catch (RepositoryException e) {
             throw new DataFetchingException(e);


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16221

## Description

Updated to only flush the nodes involved by path:
The sitemap, sitemap resource, and the jnt pages that are used for canonical URLs.
