### PR TITLE
BACKLOG-16203: Fix glob-parent security vulnerabilities in sitemap.

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,9 +70,10 @@
   "resolutions": {
     "graphql": "15.4.0",
     "@jahia/data-helper/graphql": "^15.4.0",
-    "trim-newlines": "3.0.1",
-    "css-what": "5.0.1",
-    "glob-parent": "5.1.2"
+    "**/meow/trim-newlines": "3.0.1",
+    "**/css-select/css-what": "5.0.1",
+    "**/cheerio-select-tmp/css-what": "5.0.1",
+    "**/glob-parent": "^5.1.2"
   },
   "devDependencies": {
     "@apollo/react-testing": "^3.1.3",
@@ -113,9 +114,6 @@
     "webpack": "^5.10.0",
     "webpack-bundle-analyzer": "^4.2.0",
     "webpack-cli": "^4.2.0",
-    "webpack-node-externals": "^1.7.2",
-    "trim-newlines": "^3.0.1",
-    "css-what": "^5.0.1",
-    "glob-parent": "^5.1.2"
+    "webpack-node-externals": "^1.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,9 +70,9 @@
   "resolutions": {
     "graphql": "15.4.0",
     "@jahia/data-helper/graphql": "^15.4.0",
-    "**/meow/trim-newlines": "3.0.1",
-    "**/css-select/css-what": "5.0.1",
-    "**/cheerio-select-tmp/css-what": "5.0.1",
+    "**/meow/trim-newlines": "^3.0.1",
+    "**/css-select/css-what": "^5.0.1",
+    "**/cheerio-select-tmp/css-what": "^5.0.1",
     "**/glob-parent": "^5.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "graphql": "15.4.0",
     "@jahia/data-helper/graphql": "^15.4.0",
     "trim-newlines": "3.0.1",
-    "css-what": "5.0.1"
+    "css-what": "5.0.1",
+    "glob-parent": "5.1.2"
   },
   "devDependencies": {
     "@apollo/react-testing": "^3.1.3",
@@ -114,6 +115,7 @@
     "webpack-cli": "^4.2.0",
     "webpack-node-externals": "^1.7.2",
     "trim-newlines": "^3.0.1",
-    "css-what": "^5.0.1"
+    "css-what": "^5.0.1",
+    "glob-parent": "^5.1.2"
   }
 }

--- a/tests/cypress/fixtures/getApiUser.graphql
+++ b/tests/cypress/fixtures/getApiUser.graphql
@@ -1,5 +1,0 @@
-query {
-  currentUser {
-    name
-  }
-}

--- a/tests/cypress/fixtures/workspace.graphql
+++ b/tests/cypress/fixtures/workspace.graphql
@@ -1,7 +1,0 @@
-query(
-    $workspace: Workspace
-) {
-    jcr(workspace: $workspace) {
-        workspace
-    }
-}

--- a/tests/cypress/integration/mysite.home.spec.ts
+++ b/tests/cypress/integration/mysite.home.spec.ts
@@ -37,7 +37,7 @@ describe('Enable sitemap on MySite', () => {
         siteHomePage.publishSite('My Site').clickPublishAll().flushCache()
 
         // Save the root URL
-        sitemapPage.goTo().inputSitemapRootURL('http://jahia:8080').clickOnSave().clickFlushCache()
+        sitemapPage.goTo().inputSitemapRootURL(Cypress.config().baseUrl).clickOnSave().clickFlushCache()
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500)
 
@@ -98,7 +98,7 @@ describe('Enable sitemap on MySite', () => {
         siteHomePage.publishSite('My Site').clickPublishAll().flushCache() // publish the whole site and flush
 
         // Save the root URL
-        sitemapPage.goTo().inputSitemapRootURL('http://jahia:8080').clickOnSave().clickFlushCache()
+        sitemapPage.goTo().inputSitemapRootURL(Cypress.config().baseUrl).clickOnSave().clickFlushCache()
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500)
 
@@ -159,7 +159,7 @@ describe('Enable sitemap on MySite', () => {
         siteHomePage.publishSite('My Site').clickPublishAll().flushCache() // publish the whole site and flush
 
         // Save the root URL
-        sitemapPage.goTo().inputSitemapRootURL('http://jahia:8080').clickOnSave().clickFlushCache()
+        sitemapPage.goTo().inputSitemapRootURL(Cypress.config().baseUrl).clickOnSave().clickFlushCache()
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500)
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -25,7 +25,7 @@
     "he": "^1.2.0",
     "husky": "^4.2.5",
     "istanbul-lib-coverage": "^3.0.0",
-    "jahia-reporter": "^0.2.22",
+    "jahia-reporter": "^0.2.23",
     "lint-staged": "^10.2.11",
     "mocha-junit-reporter": "^2.0.0",
     "mocha-multi-reporters": "^1.5.1",

--- a/tests/package.json
+++ b/tests/package.json
@@ -39,7 +39,11 @@
     "typescript": "^4.0.5",
     "util": "^0.12.3",
     "webpack": "^5.33.2",
-    "yarn": "^1.22.4"
+    "yarn": "^1.22.4",
+    "glob-parent": "^5.1.2"
+  },
+  "resolutions": {
+    "glob-parent": "5.1.2"
   },
   "scripts": {
     "instrument": "nyc instrument --compact=false cypress instrumented",

--- a/tests/package.json
+++ b/tests/package.json
@@ -39,11 +39,10 @@
     "typescript": "^4.0.5",
     "util": "^0.12.3",
     "webpack": "^5.33.2",
-    "yarn": "^1.22.4",
-    "glob-parent": "^5.1.2"
+    "yarn": "^1.22.4"
   },
   "resolutions": {
-    "glob-parent": "5.1.2"
+    "**/glob-parent": "^5.1.2"
   },
   "scripts": {
     "instrument": "nyc instrument --compact=false cypress instrumented",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -3867,7 +3867,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@5.1.2, glob-parent@^3.1.0, glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.2:
+glob-parent@^3.1.0, glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -3867,15 +3867,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
-  integrity sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
-  dependencies:
-    is-glob "^3.1.0"
-    path-dirname "^1.0.0"
-
-glob-parent@^5.0.0, glob-parent@^5.1.0:
+glob-parent@5.1.2, glob-parent@^3.1.0, glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -4374,7 +4366,7 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
-is-extglob@^2.1.0, is-extglob@^2.1.1:
+is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
@@ -4400,13 +4392,6 @@ is-generator-function@^1.0.7:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.8.tgz#dfb5c2b120e02b0a8d9d2c6806cd5621aa922f7b"
   integrity sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ==
-
-is-glob@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
-  integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
-  dependencies:
-    is-extglob "^2.1.0"
 
 is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
@@ -5656,11 +5641,6 @@ path-browserify@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
   integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
-
-path-dirname@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
-  integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
 
 path-exists@^4.0.0:
   version "4.0.0"

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -4615,10 +4615,10 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jahia-reporter@^0.2.22:
-  version "0.2.22"
-  resolved "https://registry.yarnpkg.com/jahia-reporter/-/jahia-reporter-0.2.22.tgz#687df5b8f252b64fcc7e78d2536a57ea921395ec"
-  integrity sha512-Uh1wbykccFnHvmVT5qogQXml7Y5oPvOZ2QpC5O6jBTR13UuIs5EwAOyFj2Y706wVNpb5VgoR96d4+zdoPNH3qw==
+jahia-reporter@^0.2.23:
+  version "0.2.23"
+  resolved "https://registry.yarnpkg.com/jahia-reporter/-/jahia-reporter-0.2.23.tgz#57600b67bfd36409736a54c0efd671ea9a4d4a18"
+  integrity sha512-MvLXrffQjJTS3ynHE3QBjbagkAoivtQ7OIGQUzRT2XmklCiXqNCXYxl+jKBdhEW2B/6SgxQtcPOsB3LuNvOAeg==
   dependencies:
     "@oclif/command" "^1"
     "@oclif/config" "^1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4256,15 +4256,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
-  integrity sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
-  dependencies:
-    is-glob "^3.1.0"
-    path-dirname "^1.0.0"
-
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0:
+glob-parent@5.1.2, glob-parent@^3.1.0, glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@^5.1.2, glob-parent@~5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -4927,7 +4919,7 @@ is-extglob@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
   integrity sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
 
-is-extglob@^2.1.0, is-extglob@^2.1.1:
+is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
@@ -4965,13 +4957,6 @@ is-glob@^2.0.0:
   integrity sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=
   dependencies:
     is-extglob "^1.0.0"
-
-is-glob@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
-  integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
-  dependencies:
-    is-extglob "^2.1.0"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
@@ -6787,11 +6772,6 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
-
-path-dirname@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
-  integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
 
 path-exists@^2.0.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3099,7 +3099,7 @@ css-vendor@^2.0.8:
     "@babel/runtime" "^7.8.3"
     is-in-browser "^1.0.2"
 
-css-what@5.0.1, css-what@^4.0.0, css-what@^5.0.1:
+css-what@5.0.1, css-what@^4.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
   integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
@@ -4256,7 +4256,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@5.1.2, glob-parent@^3.1.0, glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@^5.1.2, glob-parent@~5.1.0:
+glob-parent@^3.1.0, glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@^5.1.2, glob-parent@~5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -8695,7 +8695,7 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-trim-newlines@3.0.1, trim-newlines@^1.0.0, trim-newlines@^3.0.0, trim-newlines@^3.0.1:
+trim-newlines@3.0.1, trim-newlines@^1.0.0, trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16203

## Description

Update the glob-parent per the solution route.
The reason is our dependency is based on babel: https://github.com/babel/babel/blob/main/package.json
The babel dependencies haven't update yet.