### PR TITLE
feedbacks

### DIFF
--- a/src/main/java/org/jahia/modules/sitemap/filter/RobotsFilter.java
+++ b/src/main/java/org/jahia/modules/sitemap/filter/RobotsFilter.java
@@ -27,8 +27,12 @@ public class RobotsFilter extends AbstractFilter {
 
     @Activate
     public void activate() {
+        // TODO Why do we want it not be cached ? please consider moving this filter in a better position so it could benefit from cache system
         setPriority(15.1f); //Priority before cache filter
+        // TODO missing setApplyOnMainResource(true);
+        // TODO this filter will be triggered even for pages and other main resources displayed in pages
         setApplyOnNodeTypes(String.format("%s,%s", NO_FOLLOW_MIXIN, NO_INDEX_MIXIN));
+        // TODO why preview, no robots can crawl the preview ... ?
         setApplyOnModes("preview,live");
         setDescription("Responsible for handling 'nofollow' and 'noindex' attributes of <meta name='robots'/> tag.");
         logger.debug("Activated RobotsFilter");
@@ -36,6 +40,8 @@ public class RobotsFilter extends AbstractFilter {
 
     @Override
     public String execute(String previousOut, RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
+        // TODO optimization here: Why not checking first that the HTML contains a <head> before continue ?
+        // TODO it's done at the end of the addRobotsTag, would be better to do it before calculating stuff.
         Source source = new Source(previousOut);
         OutputDocument od = new OutputDocument(source);
         addRobotsTag(source, od, resource);

--- a/src/main/java/org/jahia/modules/sitemap/graphql/api/GqlSitemapMutation.java
+++ b/src/main/java/org/jahia/modules/sitemap/graphql/api/GqlSitemapMutation.java
@@ -67,8 +67,12 @@ public class GqlSitemapMutation {
             @GraphQLName("siteKey") @GraphQLDescription("Site key") String siteKey
     ){
         try {
+            // TODO this is completely useless to calculate the expiration here we want to delete all the caches,
+            // TODO so why calculating an expiration ?
+            // TODO also there is a big misconception here the unity is ms but we pass hours ...
             CacheUtils.refreshSitemapCache(ConversionUtils.longVal(expirationTimeDifference,
                     ConversionUtils.convertFromHour(4L)), siteKey);
+            // TODO I dont understand why we need to flush jahia output cache, the sitemap is not rendering pages ?
             CacheUtils.flushJntPages(siteKey); // Flushing specific jnt pages
             return true;
         } catch (RepositoryException e) {

--- a/src/main/java/org/jahia/modules/sitemap/services/SitemapServiceImpl.java
+++ b/src/main/java/org/jahia/modules/sitemap/services/SitemapServiceImpl.java
@@ -105,6 +105,7 @@ public class SitemapServiceImpl implements SitemapService {
                     logger.info("Site " + siteKey + " flush in progress...");
                     Long expirationTimeDifference = -1L;
                     // We are refreshing just the sitemap cache
+                    // TODO expiration unit is wrong hours instead of ms, anyway it's stupid to pass expiration when we want to flush the cache
                     CacheUtils.refreshSitemapCache(ConversionUtils.longVal(expirationTimeDifference, ConversionUtils.convertFromHour(4L)),
                             siteKey);
                 } catch (Exception e) {

--- a/src/main/resources/META-INF/patches/groovy/4.0.0-migrateSitemap.started.groovy
+++ b/src/main/resources/META-INF/patches/groovy/4.0.0-migrateSitemap.started.groovy
@@ -178,4 +178,5 @@ def runProgram() {
     System.out.println("************** Do not forget to verify and publish your site **************");
 }
 
+// TODO seem's dangerous to execute migration on all the cluster nodes, should we check for processing node ?
 runProgram();

--- a/src/main/resources/jseont_sitemap/xml/sitemap.custom.jsp
+++ b/src/main/resources/jseont_sitemap/xml/sitemap.custom.jsp
@@ -17,6 +17,7 @@
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 <%--@elvariable id="workspace" type="java.lang.String"--%>
 
+<%-- TODO remove this file if not used --%>
 <c:set target="${renderContext}" property="contentType" value="text/xml;charset=UTF-8"/>
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/main/resources/jseont_sitemap/xml/sitemap.images.jsp
+++ b/src/main/resources/jseont_sitemap/xml/sitemap.images.jsp
@@ -17,6 +17,7 @@
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 <%--@elvariable id="workspace" type="java.lang.String"--%>
 
+<%-- TODO remove this file if not used --%>
 <c:set target="${renderContext}" property="contentType" value="text/xml;charset=UTF-8"/>
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/main/resources/jseont_sitemap/xml/sitemap.jsp
+++ b/src/main/resources/jseont_sitemap/xml/sitemap.jsp
@@ -49,6 +49,7 @@
             </c:forEach>
 
             <%--  Separate sitemaps for jseomix:sitemapResource node option --%>
+            <%--  TODO why separate sitemaps does not benefit from the other languages available ? --%>
             <jcr:jqom var="additionalMaps">
                 <query:selector nodeTypeName="jseomix:sitemapResource" selectorName="stmp"/>
                 <query:descendantNode path="${renderContext.site.path}" selectorName="stmp"/>

--- a/src/main/resources/jseont_sitemap/xml/sitemap.lang.jsp
+++ b/src/main/resources/jseont_sitemap/xml/sitemap.lang.jsp
@@ -30,9 +30,11 @@
             WHERE ISDESCENDANTNODE(['${entryNode.path}'])"/>
 
 			<%-- jnt:page under currentNode --%>
+			<%-- TODO we can modify the signature of sitemap:getSitemapEntries to handle multiple type to avoid code duplicate: 'jnt:page,'jmix:mainResource' --%>
 		<c:forEach var="childUrlNode" items="${sitemap:getSitemapEntries(renderContext, entryNode.path, 'jnt:page')}">
 			<c:if test="${!sitemap:excludeNode(childUrlNode, excludeNodes.nodes)}">
 				<c:set var="urlNode" value="${childUrlNode}" scope="request"/>
+				<%-- TODO render context can be set globally outside the loop --%>
 				<c:set var="renderContext" value="${renderContext}" scope="request"/>
 				<jsp:include page="../../common/sitemap-entry.jsp"/>
 			</c:if>
@@ -42,6 +44,7 @@
 		<c:forEach var="childUrlNode" items="${sitemap:getSitemapEntries(renderContext, entryNode.path, 'jmix:mainResource')}">
 			<c:if test="${!sitemap:excludeNode(childUrlNode, excludeNodes.nodes)}">
 				<c:set var="urlNode" value="${childUrlNode}" scope="request"/>
+				<%-- TODO render context can be set globally outside the loop --%>
 				<c:set var="renderContext" value="${renderContext}" scope="request"/>
 				<jsp:include page="../../common/sitemap-entry.jsp"/>
 			</c:if>

--- a/src/main/resources/jseont_sitemap/xml/sitemap.lang.properties
+++ b/src/main/resources/jseont_sitemap/xml/sitemap.lang.properties
@@ -1,3 +1,4 @@
+# TODO remove this file if not used
 #cache.mainResource=true
 #cache.expiration=0
 #cache.perUser=true

--- a/src/main/resources/jseont_sitemap/xml/sitemap.properties
+++ b/src/main/resources/jseont_sitemap/xml/sitemap.properties
@@ -1,3 +1,4 @@
+# TODO remove this file if not used
 #cache.mainResource=true
 #cache.expiration=0
 #cache.perUser=true

--- a/src/main/resources/jseont_sitemap/xml/sitemap.resources.jsp
+++ b/src/main/resources/jseont_sitemap/xml/sitemap.resources.jsp
@@ -17,6 +17,7 @@
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 <%--@elvariable id="workspace" type="java.lang.String"--%>
 
+<%-- TODO remove this file if not used --%>
 <c:set target="${renderContext}" property="contentType" value="text/xml;charset=UTF-8"/>
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/main/resources/jseont_sitemapResource/xml/sitemapResource.jsp
+++ b/src/main/resources/jseont_sitemapResource/xml/sitemapResource.jsp
@@ -10,6 +10,7 @@
 <%--@elvariable id="currentNode" type="org.jahia.services.content.JCRNodeWrapper"--%>
 <%--@elvariable id="renderContext" type="org.jahia.services.render.RenderContext"--%>
 <%--@elvariable id="`url" type="org.jahia.services.render.URLGenerator"--%>
+<%-- TODO This JSP is a copy paste of sitemap.lang.jsp, please consider centralizing the code using a shared view --%>
 
 <c:set var="entryNode" value="${currentNode.parent}"/>
 

--- a/src/main/resources/jseont_sitemapResource/xml/sitemapResource.properties
+++ b/src/main/resources/jseont_sitemapResource/xml/sitemapResource.properties
@@ -1,3 +1,4 @@
+# TODO remove this file if not used
 #cache.mainResource=true
 #cache.expiration=0
 #cache.perUser=true


### PR DESCRIPTION
Code review additional report:

- disabling DEDICATED SITEMAP on page do not remove the jseont:sitemapResource subnode -> consider a rule to cleanup

- excluded path bug consider a page with own sitemap: /sites/digitall/events then if page exist with the name: /sites/digitall/events-community it will be consider as excluded from main sitemap. startWith bug on path, check the code it's somewhere commented.
- why dedicated sitemap for pages doesnt not benefit from multi lang listing like main sitemap ?
- there is a big session leak, we create guest session to check if the page is readable by guest but the session is never closed, please check comment, it's also somewhere. After playing a bit the the module for 1hour I got: Jahia JCR Session Load = 16.000003750762705 16.008098042718906 15.517656409235798, be careful when you see that on your local server it mean your code is leaking sessions opens. Anyway this code related to check if guest can read the node need to be optimised ASAP it's currently doing the same queries twice.
- a lot of uncessary stuff is done, code is dirty, expiration in flush function is mixing units, passing hours instead of milliseconds, anyway having expiration passed to flush function is a non sense, we want to flush no matter the expiration
- the cache system is dangerous, using the JCR to store file could really endup with problem. Imagine a cluster of 3 nodes receiving request to generate the site map a the same time ? cluster sync JCR ? etc ? Also reading binaries from JCR will not be as performant as an EHCache in-memory. We should definitely migrate the JCR caching to something else. Also separating the cache from the cluster node would be a wise idea.
- there is a lot of manual flush of the jahia output cache that I dont understand, the sitemap do not render pages, so I dont see why we should do those flush.
- the code is dirty there is utility function like: CacheUtils.refreshSitemapCache and similar function in SitemapServiceImpl.flushSitemapCaches please do consider cleaning the service layer to be more clear and readable.
- I'm probably missing stuff, but it's already a lot to consider.