### PR TITLE
BACKLOG-16959: Verify that the sitemap root only contains languages active on the site for live

### DIFF
--- a/tests/cypress/fixtures/graphql/jcrMutateProperties.graphql
+++ b/tests/cypress/fixtures/graphql/jcrMutateProperties.graphql
@@ -1,0 +1,9 @@
+mutation addProperty($pathOrId: String!, $propertyName: String!, $propertyValues: [String]!) {
+  jcr {
+    mutateNode(pathOrId: $pathOrId) {
+      mutateProperty(name: $propertyName) {
+        setValues(values: $propertyValues)
+      }
+    }
+  }
+}

--- a/tests/cypress/integration/activeLanguage.spec.ts
+++ b/tests/cypress/integration/activeLanguage.spec.ts
@@ -1,0 +1,115 @@
+import { waitUntilRefresh } from '../utils/waitUntilRefresh'
+import { configureSitemap } from '../utils/configureSitemap'
+import { deleteSitemapCache } from '../utils/deleteSitemapCache'
+
+const siteKey = 'digitall'
+const sitePath = `/sites/${siteKey}`
+const siteMapRootUrl = `${Cypress.config().baseUrl}${sitePath}`
+const sitemapUrl = `${siteMapRootUrl}/sitemap.xml`
+
+const filterLang = 'de'
+const filterPath = `/${filterLang}${sitePath}/`
+
+describe('Testing sitemap only contains language', () => {
+    let filteredUrlsforLang = 0;
+    before('Configure sitemap', () => {
+        configureSitemap(sitePath, siteMapRootUrl)
+
+        cy.log(`Verify sitemap is configured properly for site: ${sitePath}`)
+        cy.apollo({
+            variables: {
+                pathOrId: sitePath,
+                mixinsFilter: { filters: [{ fieldName: 'name', value: 'jseomix:sitemap' }] },
+                propertyNames: ['sitemapIndexURL', 'sitemapCacheDuration'],
+            },
+            queryFile: 'graphql/jcrGetSitemapConfig.graphql',
+        }).should((response: any) => {
+            const r = response?.data?.jcr?.nodeByPath
+            cy.log(JSON.stringify(r))
+            expect(r.id).not.to.be.null
+            expect(r.mixinTypes[0].name).to.equal('jseomix:sitemap')
+            expect(r.name).to.equal(siteKey)
+        })
+    })
+
+    // Before removing the language, verify the sitemap does contain
+    // links with language filterLang
+    it(`Verify that the sitemap container pages with language: ${filterLang}`, function () {
+        cy.task('parseSitemap', { url: sitemapUrl }).then((urls: Array<string>) => {
+            cy.log(`Sitemap contains: ${urls.length} URLs in total`)
+            expect(urls.length).to.be.greaterThan(0)
+
+            const filteredLang = urls.filter((u) => u.includes(filterPath))
+            cy.log(`Sitemap contains ${filteredLang.length} URLs with path: ${filterPath}`)
+            filteredUrlsforLang = filteredLang.length;
+            expect(filteredLang.length).to.be.greaterThan(0)
+        })
+    })
+
+    it(`Disable language: ${filterLang} and verify no such pages are in the sitemap anymore`, function () {
+        cy.task('parseSitemap', { url: sitemapUrl }).then((originalSitemapUrls: Array<string>) => {
+            cy.log(`Sitemap contains: ${originalSitemapUrls.length} URLs in total`)
+            expect(originalSitemapUrls.length).to.be.greaterThan(0)
+
+            // Disable language filterLang
+            cy.apollo({
+                variables: {
+                    pathOrId: sitePath,
+                    propertyName: 'j:inactiveLiveLanguages',
+                    propertyValues: [filterLang],
+                },
+                mutationFile: 'graphql/jcrMutateProperties.graphql',
+            })
+
+            // Flush cache
+            deleteSitemapCache(siteKey)
+
+            // Wait until the sitemap is modified
+            waitUntilRefresh(sitemapUrl, originalSitemapUrls)
+
+            // Fetch the new sitemaps again and test the result
+            cy.task('parseSitemap', { url: sitemapUrl }).then((newSitemapUrls: Array<string>) => {
+                cy.log(`The updated sitemap contains ${newSitemapUrls.length} URLs`)
+
+                cy.log(`The updated sitemap should contain 0 URLs with path: ${filterPath}`)
+                const filteredLang = newSitemapUrls.filter((u) => u.includes(filterPath))
+                expect(filteredLang.length).to.equal(0)
+            })
+        })
+    })
+
+    it(`Restore all languages for site ${sitePath}`, function () {
+        cy.task('parseSitemap', { url: sitemapUrl }).then((originalSitemapUrls: Array<string>) => {
+            cy.log(`Sitemap contains: ${originalSitemapUrls.length} URLs in total`)
+            expect(originalSitemapUrls.length).to.be.greaterThan(0)
+
+            cy.log(`Restore all languages for site: ${sitePath}`)
+            cy.apollo({
+                variables: {
+                    pathOrId: sitePath,
+                    propertyName: 'j:inactiveLiveLanguages',
+                    propertyValues: [],
+                },
+                mutationFile: 'graphql/jcrMutateProperties.graphql',
+            })
+
+            // Flush cache
+            deleteSitemapCache(siteKey)
+
+            // Wait until the sitemap is modified
+            waitUntilRefresh(sitemapUrl, originalSitemapUrls)
+
+            // Fetch the new sitemaps again and test the result
+            cy.task('parseSitemap', { url: sitemapUrl }).then((newSitemapUrls: Array<string>) => {
+                cy.log(`The updated sitemap contains ${newSitemapUrls.length} URLs`)
+
+                const filteredLang = newSitemapUrls.filter((u) => u.includes(filterPath))
+                cy.log(`Sitemap contains ${filteredLang.length} URLs with path: ${filterPath}`)
+                expect(filteredLang.length).to.be.greaterThan(0)
+
+                cy.log(`It should container the same number of URLs than before disabling the language: ${filteredUrlsforLang}`)
+                expect(filteredLang.length).to.equal(filteredUrlsforLang)
+            })
+        })
+    })
+})

--- a/tests/cypress/integration/publishUnpublish.spec.ts
+++ b/tests/cypress/integration/publishUnpublish.spec.ts
@@ -111,9 +111,9 @@ describe('Testing publishing and unpublishing of pages and languages', () => {
                     .filter((u) => !newSitemapUrls.includes(u))
                     .concat(newSitemapUrls.filter((u) => !originalSitemapUrls.includes(u)))
 
-                console.log(`The following URLs are different: ${JSON.stringify(difference)}`)
-
-                expect(difference.filter((u) => u.includes(testPageName)).length).to.equal(3)
+                cy.log(`The following URLs are different: ${JSON.stringify(difference)}`).then(() => {
+                    expect(difference.filter((u) => u.includes(testPageName)).length).to.equal(3)
+                })
             })
         })
     })
@@ -149,10 +149,11 @@ describe('Testing publishing and unpublishing of pages and languages', () => {
                 cy.task('parseSitemap', { url: sitemapUrl }).then((newSitemapUrls: Array<string>) => {
                     cy.log(`The updated sitemap contains ${newSitemapUrls.length} URLs`)
                     const removedUrl = originalSitemapUrls.filter((x) => !newSitemapUrls.includes(x))
-                    console.log(`The following URLs have been removed in the updated sitemap: ${JSON.stringify(removedUrl)}`)
 
-                    // In that case, the url does not contain the language in the URL
-                    expect(removedUrl.length).to.equal(1)
+                    cy.log(`The following URLs have been removed in the updated sitemap: ${JSON.stringify(removedUrl)}`).then(() => {
+                        // In that case, the url does not contain the language in the URL
+                        expect(removedUrl.length).to.equal(1)
+                    })                    
 
                     if (lang === defaultLanguage) {
                         // Find the default language URL by substracting the other languages from the original sitemap

--- a/tests/cypress/integration/publishUnpublish.spec.ts
+++ b/tests/cypress/integration/publishUnpublish.spec.ts
@@ -53,7 +53,7 @@ describe('Testing publishing and unpublishing of pages and languages', () => {
     it('Verify sitemap is configured properly for site', function () {
         cy.apollo({
             variables: {
-                pathOrId: '/sites/digitall',
+                pathOrId: sitePath,
                 mixinsFilter: { filters: [{ fieldName: 'name', value: 'jseomix:sitemap' }] },
                 propertyNames: ['sitemapIndexURL', 'sitemapCacheDuration'],
             },

--- a/tests/cypress/integration/publishUnpublish.spec.ts
+++ b/tests/cypress/integration/publishUnpublish.spec.ts
@@ -111,7 +111,7 @@ describe('Testing publishing and unpublishing of pages and languages', () => {
                     .filter((u) => !newSitemapUrls.includes(u))
                     .concat(newSitemapUrls.filter((u) => !originalSitemapUrls.includes(u)))
 
-                cy.log(`The following URLs are different: ${JSON.stringify(difference)}`)
+                console.log(`The following URLs are different: ${JSON.stringify(difference)}`)
 
                 expect(difference.filter((u) => u.includes(testPageName)).length).to.equal(3)
             })
@@ -149,7 +149,7 @@ describe('Testing publishing and unpublishing of pages and languages', () => {
                 cy.task('parseSitemap', { url: sitemapUrl }).then((newSitemapUrls: Array<string>) => {
                     cy.log(`The updated sitemap contains ${newSitemapUrls.length} URLs`)
                     const removedUrl = originalSitemapUrls.filter((x) => !newSitemapUrls.includes(x))
-                    cy.log(`The following URLs have been removed in the updated sitemap: ${JSON.stringify(removedUrl)}`)
+                    console.log(`The following URLs have been removed in the updated sitemap: ${JSON.stringify(removedUrl)}`)
 
                     // In that case, the url does not contain the language in the URL
                     expect(removedUrl.length).to.equal(1)


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-16959

Description in the title, need for this test was identified during a team discussion.