### PR TITLE
QA-14165: Include current language in the list of alternates

### DIFF
--- a/src/main/java/org/jahia/modules/sitemap/utils/Utils.java
+++ b/src/main/java/org/jahia/modules/sitemap/utils/Utils.java
@@ -95,9 +95,6 @@ public final class Utils {
         // look for other languages
         List<SitemapEntry> linksInOtherLanguages = new ArrayList<>();
         for (Locale otherLocale : node.getResolveSite().getActiveLiveLanguagesAsLocales()) {
-            if (otherLocale.equals(currentLocale)) {
-                continue;
-            }
             JCRTemplate.getInstance().doExecute(guestUser, Constants.LIVE_WORKSPACE, otherLocale, sessionInOtherLocale -> {
                 if (!sessionInOtherLocale.nodeExists(node.getPath())) {
                     return null;

--- a/tests/cypress/integration/xml/sitemap.lang.spec.ts
+++ b/tests/cypress/integration/xml/sitemap.lang.spec.ts
@@ -25,15 +25,11 @@ describe('Check sitemap-lang.xml file on digitall', () => {
         removeSitemapConfiguration(sitePath)
     })
 
-    it('alternate url should not contains the default language', () => {
+    it('alternate url should not contains all three languages', () => {
         cy.requestFindXMLElementByTagName(langEn + sitemapLangFilePath, 'url').then((urls) => {
             Cypress.$(urls).each(($idx, $list) => {
                 const nodeItems = $list.getElementsByTagName('xhtml:link')
-                if (nodeItems.length > 0) {
-                    for (const c of nodeItems) {
-                        cy.wrap(c.getAttribute('hreflang')).should('not.contain', langEn)
-                    }
-                }
+                expect(nodeItems.length).to.equal(languages.length)
             })
         })
     })


### PR DESCRIPTION
As per: https://developers.google.com/search/docs/advanced/crawling/localized-versions?hl=en&visit_id=637841353602896169-3811074270&rd=1#sitemap

```
Each <url> element must have a child element <xhtml:link rel="alternate" hreflang="supported_language-code"> that lists every alternate version of the page, including itself
```