### PR TITLE
QA-14850: usage of doExecuteWithSystemSessionAsUser to prevent map ex…

### DIFF
--- a/src/main/java/org/jahia/modules/sitemap/utils/Utils.java
+++ b/src/main/java/org/jahia/modules/sitemap/utils/Utils.java
@@ -145,7 +145,9 @@ public final class Utils {
         // look for other languages
         List<SitemapEntry> linksInOtherLanguages = new ArrayList<>();
         for (Locale otherLocale : node.getResolveSite().getActiveLiveLanguagesAsLocales()) {
-            JCRTemplate.getInstance().doExecute(guestUser, Constants.LIVE_WORKSPACE, otherLocale, sessionInOtherLocale -> {
+            // The "main" node existing, we use doExecuteWithSystemSessionAsUser to retrieve the I18n nodes to prevent map explosion (cf https://jira.jahia.org/browse/QA-14850 )
+            // The "main" node being restrieved by a guest session, we have no security issue when retrieving i18ns nodes with system session
+            JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(guestUser, Constants.LIVE_WORKSPACE, otherLocale, sessionInOtherLocale -> {
                 if (!sessionInOtherLocale.nodeExists(node.getPath())) {
                     return null;
                 }


### PR DESCRIPTION
…plosion

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14850

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Instead of using JCRTemplate.getInstance().doExecute as a guest, which was leading to an "explosion" of the map org.apache.jackrabbit.core.security.JahiaLoginModule.systemPass, we use  JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [x] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
