### PR TITLE
BACKLOG-21425: Run sitemap nightly tests on Jahia SN and Jahia Release

### DIFF
--- a/.github/workflows/nightly-standalone-release.yml
+++ b/.github/workflows/nightly-standalone-release.yml
@@ -1,4 +1,4 @@
-name: Nightly Test run
+name: Nightly (Jahia Release)
 
 on:
   workflow_dispatch:
@@ -7,12 +7,10 @@ on:
 
 jobs:
   integration-tests-standalone:
-    name: Integration Tests (Standalone)
+    name: Integration Tests (Standalone - Release)
     runs-on: self-hosted
     strategy:
       fail-fast: false
-      matrix:
-        jahia_image: ["jahia/jahia-ee:8", "jahia/jahia-ee-dev:8-SNAPSHOT"]
     timeout-minutes: 45
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
@@ -28,12 +26,13 @@ jobs:
           module_id: sitemap
           testrail_project: Sitemap Module
           tests_manifest: provisioning-manifest-snapshot.yml
+          jahia_image: jahia/jahia-ee:8
           should_use_build_artifacts: false
           should_skip_artifacts: true
           should_skip_notifications: true
           should_skip_testrail: false
           should_skip_zencrepes: true
-          github_artifact_name: sitemap-artifacts-${{ matrix.jahia_image }}-${{ github.run_number }}
+          github_artifact_name: sitemap-standalone-release-artifacts-${{ github.run_number }}
           bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
           jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
           docker_username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/nightly-standalone-snapshot.yml
+++ b/.github/workflows/nightly-standalone-snapshot.yml
@@ -1,0 +1,59 @@
+name: Nightly (Jahia Snapshot)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  integration-tests-standalone:
+    name: Integration Tests (Standalone - Snapshot)
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+    timeout-minutes: 45
+    steps:
+      - uses: jahia/jahia-modules-action/helper@v2
+      - uses: KengoTODA/actions-setup-docker-compose@main
+        with:
+          version: '1.29.2'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+      - uses: actions/checkout@v3
+      - uses: jahia/jahia-modules-action/integration-tests@v2
+        with:
+          module_id: sitemap
+          testrail_project: Sitemap Module
+          tests_manifest: provisioning-manifest-snapshot.yml
+          jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
+          should_use_build_artifacts: false
+          should_skip_artifacts: true
+          should_skip_notifications: true
+          should_skip_testrail: false
+          should_skip_zencrepes: true
+          github_artifact_name: sitemap-standalone-snapshot-artifacts--${{ github.run_number }}
+          bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
+          jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
+          docker_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          docker_password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+          testrail_username: ${{ secrets.TESTRAIL_USERNAME }}
+          testrail_password: ${{ secrets.TESTRAIL_PASSWORD }}
+          tests_report_name: Test report (Standalone)
+          incident_pagerduty_api_key: ${{ secrets.INCIDENT_PAGERDUTY_API_KEY }}
+          incident_pagerduty_reporter_email: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_EMAIL }}
+          incident_pagerduty_reporter_id: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_ID }}
+          incident_google_spreadsheet_id: ${{ secrets.INCIDENT_GOOGLE_SPREADSHEET_ID }}
+          incident_google_client_email: ${{ secrets.INCIDENT_GOOGLE_CLIENT_EMAIL }}
+          incident_google_api_key_base64: ${{ secrets.INCIDENT_GOOGLE_PRIVATE_KEY_BASE64 }}
+          zencrepes_secret: ${{ secrets.ZENCREPES_WEBHOOK_SECRET }}
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: Tests Report (Standalone)
+          path: tests/artifacts/results/xml_reports/*.xml
+          reporter: java-junit
+          fail-on-error: 'false'

--- a/tests/provisioning-manifest-build.yml
+++ b/tests/provisioning-manifest-build.yml
@@ -17,7 +17,6 @@
     - 'mvn:org.jahia.modules/dx-base-demo-templates/3.1.0'
     - 'mvn:org.jahia.modules/dx-base-demo-components/2.2.0'
     - 'mvn:org.jahia.modules/digitall/2.1.0'
-    - 'mvn:org.jahia.modules/site-settings-seo/3.2.0-SNAPSHOT'
     - 'mvn:org.jahia.modules/graphql-dxm-provider'
   autoStart: true
   uninstallPreviousVersion: true

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -17,7 +17,6 @@
     - 'mvn:org.jahia.modules/dx-base-demo-templates/3.1.0'
     - 'mvn:org.jahia.modules/dx-base-demo-components/2.2.0'
     - 'mvn:org.jahia.modules/digitall/2.1.0'
-    - 'mvn:org.jahia.modules/site-settings-seo/3.2.0-SNAPSHOT'
     - 'mvn:org.jahia.modules/graphql-dxm-provider'
     - 'mvn:org.jahia.modules/sitemap/LATEST'
   autoStart: true


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-21425
NB: In nearly past there was a specific dependency on a version of site-settings-seo and we're likely to find ourselves in the same situation for some time (cf. jContent 3x). We split the existing workflow in order to test the module on the jahia release version and the snapshot version.
