### PR TITLE
BACKLOG-21912: allow any user to get sitemap job status by removing the scheduler service call.

### DIFF
--- a/src/javascript/components/SitemapPanelHeader/SitemapPanelHeader.jsx
+++ b/src/javascript/components/SitemapPanelHeader/SitemapPanelHeader.jsx
@@ -28,9 +28,8 @@ export const SitemapPanelHeaderComponent = ({
         fetchPolicy: 'no-cache'
     });
     useEffect(() => {
-        const jobStatus = jobsStatusResult?.data?.admin?.jahia?.scheduler.jobs.find(job => job.group === 'SitemapCreationJob' && job.name === siteKey)?.jobStatus;
-        setTriggered(jobStatus === 'EXECUTING' || jobsStatusResult?.data?.jcr?.nodeByPath?.property?.isSitemapJobTriggered);
-    }, [jobsStatusResult, siteKey]);
+        setTriggered(jobsStatusResult?.data?.jcr?.nodeByPath?.property?.isSitemapJobTriggered);
+    }, [jobsStatusResult]);
 
     const [submitToGoogleMutation] = useMutation(gqlMutations.sendSitemapToSearchEngine, {
         variables: {

--- a/src/javascript/components/SitemapPanelHeader/gqlQueries.js
+++ b/src/javascript/components/SitemapPanelHeader/gqlQueries.js
@@ -11,19 +11,6 @@ const getJobsStatus = gql`
                 ...NodeCacheRequiredFields
             }
         }
-        admin {
-            jahia {
-                scheduler {
-                    jobs {
-                        name
-                        group
-                        jobState
-                        jobStatus
-                        duration
-                    }
-                }
-            }
-        }
     }
     ${PredefinedFragments.nodeCacheRequiredFields.gql}
 `;

--- a/src/main/java/org/jahia/modules/sitemap/job/SitemapCreationJob.java
+++ b/src/main/java/org/jahia/modules/sitemap/job/SitemapCreationJob.java
@@ -51,6 +51,12 @@ public class SitemapCreationJob extends BackgroundJob {
     public void executeJahiaJob(JobExecutionContext jobExecutionContext) throws Exception {
         final ClassLoader initialClassLoader = Thread.currentThread().getContextClassLoader();
         try {
+            // Set the job as running (in case of a scheduled job)
+            JCRTemplate.getInstance().doExecuteWithSystemSession(session ->  {
+                JahiaSitesService.getInstance().getSiteByKey(jobExecutionContext.getJobDetail().getName(), session).setProperty("isSitemapJobTriggered", true);
+                session.save();
+                return null;
+            });
             // Switch class loader to Jahia (for url rewrite service)
             Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
             SitemapService sitemapService = BundleUtils.getOsgiService(SitemapService.class, null);


### PR DESCRIPTION
the job status flag is now set at the job startup to avoid to call the admin graphql endpoint to ensure site users allowed to get job status