### PR TITLE
BACKLOG-22109 : fix job state detection in sitemap UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,7 @@
     </scm>
     <properties>
         <export-package>org.jahia.modules.sitemap.utils</export-package>
-        <jahia-module-signature>MCwCFCqldpe7u3Igm+Y+iuPr3fFtpJG0AhRktbOL7DjdU0pSLne54devt62mCw==
-        </jahia-module-signature>
+        <jahia-module-signature>MC0CFFSzB5xTNAxdKg6/Fgu9v7FOcQXEAhUAkNSgVs0kXoncVBYk7r17hHbWOks=</jahia-module-signature>
         <yarn.arguments>build:production</yarn.arguments>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"
         </require-capability>

--- a/src/javascript/components/SitemapPanelHeader/SitemapPanelHeader.jsx
+++ b/src/javascript/components/SitemapPanelHeader/SitemapPanelHeader.jsx
@@ -21,7 +21,7 @@ export const SitemapPanelHeaderComponent = ({
     const [dialogIsOpen, setDialogIsOpen] = useState(false);
     const [isTriggered, setTriggered] = useState(false);
     const [dialogInfo, setDialogInfo] = useState(null);
-    const {data, refetch, startPolling, stopPolling} = useQuery(getJobsStatus, {
+    const {data, startPolling, stopPolling} = useQuery(getJobsStatus, {
         variables: {
             path: '/sites/' + siteKey
         },
@@ -29,7 +29,8 @@ export const SitemapPanelHeaderComponent = ({
         fetchPolicy: 'no-cache'
     });
     useEffect(() => {
-        setTriggered(data?.jcr?.nodeByPath?.property?.isSitemapJobTriggered);
+        const remoteTriggerState = Boolean(data?.jcr?.nodeByPath?.property?.isSitemapJobTriggered);
+        setTriggered(remoteTriggerState);
     }, [data]);
 
     const [submitToGoogleMutation] = useMutation(gqlMutations.sendSitemapToSearchEngine, {
@@ -56,7 +57,6 @@ export const SitemapPanelHeaderComponent = ({
         onCompleted: data => {
             setTriggered(true);
             stopPolling();
-            refetch().then(data => setTriggered(data?.jcr?.nodeByPath?.property?.isSitemapJobTriggered));
             startPolling(1000);
             snackBarInfo({message: t('labels.snackbar.triggerSitemapJob')});
             openSnackBar(true);

--- a/src/main/java/org/jahia/modules/sitemap/job/SitemapCreationJob.java
+++ b/src/main/java/org/jahia/modules/sitemap/job/SitemapCreationJob.java
@@ -191,8 +191,12 @@ public class SitemapCreationJob extends BackgroundJob {
         } finally {
             // Clear job marker
             JCRTemplate.getInstance().doExecuteWithSystemSession(session ->  {
-                JahiaSitesService.getInstance().getSiteByKey(jobExecutionContext.getJobDetail().getName(), session).getProperty("isSitemapJobTriggered").remove();
-                session.save();
+                JCRSiteNode siteNode = JahiaSitesService.getInstance().getSiteByKey(jobExecutionContext.getJobDetail().getName(), session);
+                // This can happen if the sitemap module is uninstalled from a site as the job is running.
+                if (siteNode.hasProperty("isSitemapJobTriggered")) {
+                    siteNode.getProperty("isSitemapJobTriggered").remove();
+                    session.save();
+                }
                 return null;
             });
             // No need to close sessions as it's automatically done at the end of the job


### PR DESCRIPTION
- remove not required call that was breaking the UI
- avoid an exception in the console in case the module uninstalled on a site while the sitemap generation is running