### PR TITLE
BACKLOG-22343 : extend version range of graphql dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,13 @@
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"
         </require-capability>
         <sonar.sources>src/javascript</sonar.sources>
+        <jahia.plugin.version>6.9</jahia.plugin.version>
         <import-package>graphql.annotations.annotationTypes;version="[7.2,99)",
             graphql.annotations.connection;version="[7.2,99)",
             graphql.schema;version="[13.0,99)",
-            graphql;version="[13.0,99)"
+            graphql;version="[13.0,99)",
+            org.jahia.modules.graphql.provider.dxm;version="[2.7,4)",
+            org.jahia.modules.graphql.provider.dxm.util;version="[2.7,4)"
         </import-package>
         <jahia-depends>site-settings-seo,graphql-dxm-provider,default</jahia-depends>
     </properties>
@@ -83,15 +86,6 @@
         </repository>
     </repositories>
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.jahia.server</groupId>
-                    <artifactId>jahia-maven-plugin</artifactId>
-                    <version>6.9</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-22343

Extend compatibility range of graphql dependency