### PR TITLE
BACKLOG-22137 : fix cypress test following changes in vanity url encoding

### DIFF
--- a/src/javascript/components/SitemapPanelHeader/SitemapPanelHeader.jsx
+++ b/src/javascript/components/SitemapPanelHeader/SitemapPanelHeader.jsx
@@ -30,7 +30,6 @@ export const SitemapPanelHeaderComponent = ({
         fetchPolicy: 'no-cache'
     });
     useEffect(() => {
-        console.debug('Current timer: ' + timer);
         const remoteTriggerState = Boolean(data?.jcr?.nodeByPath?.property?.isSitemapJobTriggered);
         setTriggered(remoteTriggerState);
     }, [data, timer]);

--- a/tests/cypress/integration/xml/sitemap.encoding.ts
+++ b/tests/cypress/integration/xml/sitemap.encoding.ts
@@ -64,8 +64,6 @@ describe('Check sitemap links are encoded correctly', () => {
         // create pages with vanity for encoding test: vanities
         createPage(homePath + '/encoding-sitemap-test/sitemap-vanities', 'vanity&ü', false)
         addVanityUrl(homePath + '/encoding-sitemap-test/sitemap-vanities/vanity&ü', 'actual-vanity&ü')
-        createPage(homePath + '/encoding-sitemap-test/sitemap-vanities', 'vanity"ü', false)
-        addVanityUrl(homePath + '/encoding-sitemap-test/sitemap-vanities/vanity"ü', 'actual-vanity"ü')
         createPage(homePath + '/encoding-sitemap-test/sitemap-vanities', "vanity'ü", false)
         addVanityUrl(homePath + "/encoding-sitemap-test/sitemap-vanities/vanity'ü", "actual-vanity'ü")
         createPage(homePath + '/encoding-sitemap-test/sitemap-vanities', 'vanity>ü', false)
@@ -104,8 +102,8 @@ describe('Check sitemap links are encoded correctly', () => {
         })
     })
 
-    it.skip('Check encoding for sitemap pages with vanities', () => {
-        const names = ['/actual-vanity&amp;%C3%BC', '/actual-vanity&apos;%C3%BC', '/actual-vanity&quot;%C3%BC']
+    it('Check encoding for sitemap pages with vanities', () => {
+        const names = ['/actual-vanity&amp;%C3%BC', '/actual-vanity&apos;%C3%BC']
 
         generateSitemap(siteKey)
         cy.request('en/sites/digitall/sitemap-lang.xml').then((response) => {


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-22137 
- remove vanity with quote from cypress test as now vanity with quotes cannot be created
- remove non-relevant log in javascript console