### PR TITLE
TECH-1416: Update guava dependency for compatibility Jahia 8.1 and 8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
                     <instructions>
                         <_dsannotations>*</_dsannotations>
                         <Import-Package>
+                            ${jahia.plugin.projectPackageImport},
                             com.google.common.base;version="[30.1,34)",
                             graphql.annotations.annotationTypes;version="[7.2,99)",
                             graphql.annotations.connection;version="[7.2,99)",

--- a/pom.xml
+++ b/pom.xml
@@ -25,16 +25,6 @@
         </require-capability>
         <sonar.sources>src/javascript</sonar.sources>
         <jahia.plugin.version>6.9</jahia.plugin.version>
-        <import-package>
-            graphql.annotations.annotationTypes;version="[7.2,99)",
-            graphql.annotations.connection;version="[7.2,99)",
-            graphql.schema;version="[13.0,99)",
-            graphql;version="[13.0,99)",
-            org.jahia.modules.graphql.provider.dxm;version="[2.8,4)",
-            org.jahia.modules.graphql.provider.dxm.util;version="[2.8,4)",
-            org.jahia.modules.graphql.provider.dxm.admin;version="[2.8,4)",
-            org.jahia.modules.graphql.provider.dxm.osgi.annotations;version="[2.8,4)"
-        </import-package>
         <jahia-depends>site-settings-seo,graphql-dxm-provider,default</jahia-depends>
     </properties>
     <dependencies>
@@ -97,6 +87,18 @@
                 <configuration>
                     <instructions>
                         <_dsannotations>*</_dsannotations>
+                        <Import-Package>
+                            com.google.common.base;version="[30.1,34)",
+                            graphql.annotations.annotationTypes;version="[7.2,99)",
+                            graphql.annotations.connection;version="[7.2,99)",
+                            graphql.schema;version="[13.0,99)",
+                            graphql;version="[13.0,99)",
+                            org.jahia.modules.graphql.provider.dxm;version="[2.8,4)",
+                            org.jahia.modules.graphql.provider.dxm.util;version="[2.8,4)",
+                            org.jahia.modules.graphql.provider.dxm.admin;version="[2.8,4)",
+                            org.jahia.modules.graphql.provider.dxm.osgi.annotations;version="[2.8,4)",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/TECH-1416

## Description

Set Guava OSGI Range from 30.1 to 34 in pom to ensure compatibility with jahia 8.1 and 8.2

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
