### PR TITLE
fix: namespace declarations in Sitemap XML

### DIFF
--- a/src/main/java/org/jahia/modules/sitemap/job/SitemapCreationJob.java
+++ b/src/main/java/org/jahia/modules/sitemap/job/SitemapCreationJob.java
@@ -136,10 +136,8 @@ public class SitemapCreationJob extends BackgroundJob {
                                 Document doc = docBuilder.newDocument();
                                 doc.setXmlStandalone(true);
                                 Element rootSitemap = doc.createElement("urlset");
-                                rootSitemap.setAttribute("xmlns:xsi", "https://www.w3.org/2001/XMLSchema-instance");
-                                rootSitemap.setAttribute("xsi:schemaLocation", "https://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd https://www.w3.org/1999/xhtml https://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd");
-                                rootSitemap.setAttribute("xmlns", "https://www.w3.org/2001/XMLSchema-instance");
-                                rootSitemap.setAttribute("xmlns:xhtml", "https://www.w3.org/1999/xhtml");
+                                rootSitemap.setAttribute("xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9");
+                                rootSitemap.setAttribute("xmlns:xhtml", "http://www.w3.org/1999/xhtml");
                                 doc.appendChild(rootSitemap);
                                 for (SitemapEntry entry : entries) {
                                     if (isDebug) {


### PR DESCRIPTION
- Updated `<urlset>` to use correct `xmlns` and `xmlns:xhtml` as per specs.
- Removed unnecessary `xsi:schemaLocation` and `xmlns:xsi`.

## JIRA

https://jira.jahia.org/browse/QA-15376

## Description

This PR fixes the namespace declarations in the sitemap XML generation:
- Ensures compliance with sitemap specifications by using the correct `xmlns` and `xmlns:xhtml` declarations.
- Removes redundant and unused attributes (`xsi:schemaLocation`, `xmlns:xsi`) to simplify the XML structure.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change:

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [ ] Migration
- [x] Code maintainability
