### PR TITLE
fix: schedule sitemap job if sitemap configured

### DIFF
--- a/src/main/java/org/jahia/modules/sitemap/services/impl/SitemapServiceImpl.java
+++ b/src/main/java/org/jahia/modules/sitemap/services/impl/SitemapServiceImpl.java
@@ -84,7 +84,7 @@ public class SitemapServiceImpl implements SitemapService {
         JCRTemplate.getInstance().doExecuteWithSystemSession(session -> {
             try {
                 for (JCRSiteNode siteNode : JahiaSitesService.getInstance().getSitesNodeList(session)) {
-                    if (siteNode.getInstalledModules().contains("sitemap")) {
+                    if (siteNode.getInstalledModules().contains("sitemap") && siteNode.isNodeType(Utils.DEDICATED_SITEMAP_MIXIN)) {
                         scheduleSitemapJob(siteNode.getSiteKey(), siteNode.getPropertyAsString("sitemapCacheDuration"));
                     }
                 }

--- a/src/main/java/org/jahia/modules/sitemap/utils/Utils.java
+++ b/src/main/java/org/jahia/modules/sitemap/utils/Utils.java
@@ -72,14 +72,14 @@ public final class Utils {
 
     private static final Logger logger = LoggerFactory.getLogger(Utils.class);
 
-    private static final String DEDICATED_SITEMAP_MIXIN = "jseomix:sitemapResource";
     private static final String NO_INDEX_MIXIN = "jseomix:noIndex";
     private static final String[] ENTITIES = new String[]{"&amp;", "&apos;", "&quot;", "&gt;", "&lt;"};
     private static final String[] ENCODED_ENTITIES = new String[]{"_-amp-_", "_-apos-_", "_-quot-_", "_-gt-_", "_-lt-_"};
 
     private static final UrlRewriteService urlRewriteService = BundleUtils.getOsgiService(UrlRewriteService.class, null);
 
-
+    public static final String DEDICATED_SITEMAP_MIXIN = "jseomix:sitemapResource";
+    
     private Utils() {
     }
 


### PR DESCRIPTION
### Description
Prevent the schedule of the job SitemapCreationJob if the mixin jseomix:sitemap is not present (it means, when the sitemap is not configured)

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
