### PR TITLE
feat: provide simplify sitemap for single language link

### DIFF
--- a/src/main/java/org/jahia/modules/sitemap/utils/Utils.java
+++ b/src/main/java/org/jahia/modules/sitemap/utils/Utils.java
@@ -45,7 +45,6 @@ import org.jahia.services.sites.JahiaSitesService;
 import org.jahia.services.usermanager.JahiaUser;
 import org.jahia.settings.SettingsBean;
 import org.jahia.utils.LanguageCodeConverters;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.touk.throwing.ThrowingConsumer;
@@ -175,7 +174,7 @@ public final class Utils {
      * generate sitemap entries that are publicly accessible, store them in entriesByLocale and entriesByPath parameters
      */
     public static void generateSitemapEntries(Map<Locale, JCRSessionWrapper> sessionPerLocale, RenderContext renderContext, String rootPath, Set<String> sitemapRoots, Map<Locale, Set<SitemapEntry>> entriesByLocale, Map<String, Set<SitemapEntry>> entriesByPath) throws RepositoryException {
-         SitemapConfigService config = BundleUtils.getOsgiService(SitemapConfigService.class, null);
+        SitemapConfigService config = BundleUtils.getOsgiService(SitemapConfigService.class, null);
         if (config == null) {
             logger.error("Configuration service SitemapConfigService not revolved, check OSGi services status");
             return;
@@ -383,4 +382,3 @@ public final class Utils {
     }
 
 }
-

--- a/src/main/java/org/jahia/modules/sitemap/utils/Utils.java
+++ b/src/main/java/org/jahia/modules/sitemap/utils/Utils.java
@@ -45,6 +45,7 @@ import org.jahia.services.sites.JahiaSitesService;
 import org.jahia.services.usermanager.JahiaUser;
 import org.jahia.settings.SettingsBean;
 import org.jahia.utils.LanguageCodeConverters;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.touk.throwing.ThrowingConsumer;

--- a/tests/cypress/integration/xml/sitemap.encoding.ts
+++ b/tests/cypress/integration/xml/sitemap.encoding.ts
@@ -1,7 +1,7 @@
 import { configureSitemap } from '../../utils/configureSitemap'
 import { removeSitemapConfiguration } from '../../utils/removeSitemapConfiguration'
-import { publishAndWaitJobEnding } from '../../utils/publishAndWaitJobEnding'
 import { generateSitemap } from '../../utils/generateSitemap'
+import { publishAndWaitJobEnding, setNodeProperty } from '@jahia/cypress'
 
 const siteKey = 'digitall'
 const sitePath = '/sites/' + siteKey
@@ -17,6 +17,9 @@ const createPage = (parent, name, dedicatedSiteMap = undefined) => {
         },
         mutationFile: 'graphql/jcrAddPage.graphql',
     })
+    // Set title of home in French
+    setNodeProperty(parent + '/' + name, 'jcr:title', 'home FR', 'fr')
+
     if (dedicatedSiteMap) {
         cy.apollo({
             variables: {
@@ -70,7 +73,7 @@ describe('Check sitemap links are encoded correctly', () => {
         addVanityUrl(homePath + '/encoding-sitemap-test/sitemap-vanities/vanity ü', 'actual-vanity ü')
         addVanityUrl(homePath + '/encoding-sitemap-test/sitemap-vanities/vanity ü', 'actual-vanity ä')
 
-        publishAndWaitJobEnding(homePath + '/encoding-sitemap-test')
+        publishAndWaitJobEnding(homePath + '/encoding-sitemap-test', ['en', 'fr'])
 
         configureSitemap(sitePath, Cypress.config().baseUrl + sitePath)
     })
@@ -82,7 +85,7 @@ describe('Check sitemap links are encoded correctly', () => {
             },
             mutationFile: 'graphql/jcrDeleteNode.graphql',
         })
-        publishAndWaitJobEnding(homePath)
+        publishAndWaitJobEnding(homePath, ['en', 'fr'])
         removeSitemapConfiguration(sitePath)
     })
 

--- a/tests/cypress/integration/xml/sitemap.lang.spec.ts
+++ b/tests/cypress/integration/xml/sitemap.lang.spec.ts
@@ -36,7 +36,7 @@ describe('Check sitemap-lang.xml file on digitall', () => {
         })
     })
 
-    it.only('alternate url should not contains invalid language', () => {
+    it('alternate url should not contains invalid language', () => {
         // update history page to invalid 'de' language
         cy.apollo({
             variables: {

--- a/tests/cypress/integration/xml/sitemap.lang.spec.ts
+++ b/tests/cypress/integration/xml/sitemap.lang.spec.ts
@@ -36,7 +36,7 @@ describe('Check sitemap-lang.xml file on digitall', () => {
         })
     })
 
-    it('alternate url should not contains invalid language', () => {
+    it.only('alternate url should not contains invalid language', () => {
         // update history page to invalid 'de' language
         cy.apollo({
             variables: {

--- a/tests/cypress/integration/xml/sitemap.singleLang.ts
+++ b/tests/cypress/integration/xml/sitemap.singleLang.ts
@@ -1,0 +1,97 @@
+import {
+    createSite,
+    deleteSite,
+    enableModule,
+    publishAndWaitJobEnding,
+    setNodeProperty,
+    unpublishNode,
+} from '@jahia/cypress'
+import { configureSitemap } from '../../utils/configureSitemap'
+import { generateSitemap } from '../../utils/generateSitemap'
+
+const siteKey = 'singleLanguageSite'
+const path = `/sites/${siteKey}`
+
+describe('Test site with one language', () => {
+    beforeEach(() => {
+        // Set up a site with a single language
+        deleteSite(siteKey)
+        createSite(siteKey, {
+            languages: 'en, fr',
+            templateSet: 'dx-demo-templates',
+            serverName: 'localhost',
+            locale: 'en',
+        })
+        // Set title of home in French
+        setNodeProperty(path + '/home', 'jcr:title', 'home FR', 'fr')
+        // Enable sitemap module and configure it
+        enableModule('sitemap', siteKey)
+        configureSitemap(path, Cypress.config().baseUrl + path)
+        // Publish the site
+        publishAndWaitJobEnding(path, ['en', 'fr'])
+    })
+
+    afterEach(() => {
+        deleteSite(siteKey)
+    })
+
+    it('Should generate a simplified sitemap for single language site', () => {
+        // Generate the sitemap
+        generateSitemap(siteKey)
+
+        // Wait for the sitemap to be properly generated
+        cy.waitUntil(
+            () =>
+                cy
+                    .request({
+                        url: Cypress.config().baseUrl + path + '/sitemap-lang.xml',
+                        failOnStatusCode: false,
+                    })
+                    .then((response) => {
+                        return (
+                            response.status === 200 &&
+                            response.body.includes('<urlset') &&
+                            response.body.includes('<url>')
+                        )
+                    }),
+            {
+                timeout: 10000,
+                interval: 500,
+                errorMsg: 'Sitemap was not properly generated within the timeout period',
+            },
+        )
+
+        // Verify the content of the sitemap
+        cy.requestFindXMLElementByTagName(Cypress.config().baseUrl + path + '/sitemap-lang.xml', 'url').then((urls) => {
+            // Ensure we have at least one URL entry
+            expect(urls).to.have.length.at.least(1, 'Sitemap should contain at least one URL entry')
+        })
+
+        // Check that multilang behavior is working
+        // verify that xhtml:link elements exist
+        cy.requestFindXMLElementByTagName(Cypress.config().baseUrl + path + '/sitemap-lang.xml', 'xhtml:link').then(
+            (links) => {
+                expect(links).to.not.be.empty
+            },
+        )
+
+        // Unpublish french
+        unpublishNode(path + '/home', 'fr')
+
+        // Generate sitemap
+        generateSitemap(siteKey)
+
+        // Verify the content of the sitemap
+        cy.requestFindXMLElementByTagName(Cypress.config().baseUrl + path + '/sitemap-lang.xml', 'url').then((urls) => {
+            // Ensure we have at least one URL entry
+            expect(urls).to.have.length.at.least(1, 'Sitemap should contain at least one URL entry')
+        })
+
+        // verify that xhtml:link elements do not exist
+        cy.requestFindXMLElementByTagName(Cypress.config().baseUrl + path + '/sitemap-lang.xml', 'xhtml:link').then(
+            (links) => {
+                expect(links).to.be.empty
+            },
+        )
+    })
+})


### PR DESCRIPTION
Now links with one language instead of being generated in sitemap like this:

```xml
<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
  <url>
    <lastmod>2025-06-25</lastmod>
    <loc>http://jahia:8080/sites/singleLanguageSite/home.html</loc>
    <xhtml:link href="http://jahia:8080/sites/singleLanguageSite/home.html" hreflang="x-default" rel="alternate"/>
    <xhtml:link href="http://jahia:8080/sites/singleLanguageSite/home.html" hreflang="en" rel="alternate"/>
  </url>
</urlset>
```

are like this

```xml
<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
  <url>
    <lastmod>2025-06-25</lastmod>
    <loc>http://jahia:8080/sites/singleLanguageSite/home.html</loc>
  </url>
</urlset>
```

Covered by Cypress test. 