### PR TITLE
test: Add healthcheck on MariaDB container

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -19,6 +19,11 @@ services:
       MYSQL_DATABASE: jahia
       MYSQL_USER: jahia
       MYSQL_PASSWORD: jahia
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-proot1234"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
 
   # Cypress container
   cypress:
@@ -46,7 +51,8 @@ services:
     # hostname: 'jahia.dev.sandbox.jahia.com'
     container_name: jahia
     depends_on:
-      - mariadb
+      mariadb:
+        condition: service_healthy
     networks:
       jahia-net:
         ipv4_address: 172.24.24.50


### PR DESCRIPTION
### Description
Wait for MariaDB container to be fully started and ready before starting the Jahia container.

This seems to fix the error faced on startup during the _Nightly Test run (Cluster)_ (for instance [this run](https://github.com/Jahia/sitemap/actions/runs/20370686534/job/58536280512)):
```
2025-12-19 13:03:36,021: ERROR [ContextLoader] - Context initialization failed
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'workflowService' defined in URL [jar:file:/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/jahia-impl-8.2.3.0-SNAPSHOT.jar!/org/jahia/defaults/config/spring/workflow/applicationcontext-workflow.xml]: Cannot resolve reference to bean 'jcrTemplate' while setting bean property 'jcrTemplate'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'jcrTemplate' defined in URL [jar:file:/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/jahia-impl-8.2.3.0-SNAPSHOT.jar!/org/jahia/defaults/config/spring/jcr/applicationcontext-jcr.xml]: Cannot resolve reference to bean 'jcrSessionFactory' while setting bean property 'sessionFactory'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'jcrSessionFactory' defined in URL [jar:file:/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/jahia-impl-8.2.3.0-SNAPSHOT.jar!/org/jahia/defaults/config/spring/jcr/applicationcontext-jcr.xml]: Cannot resolve reference to bean 'JahiaUserManagerService' while setting bean property 'userService'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'JahiaUserManagerService' defined in URL [jar:file:/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/jahia-impl-8.2.3.0-SNAPSHOT.jar!/org/jahia/defaults/config/spring/users-groups/applicationcontext-users.xml]: Cannot resolve reference to bean 'settingsBean' while setting bean property 'settingsBean'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'settingsBean' defined in URL [jar:file:/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/jahia-impl-8.2.3.0-SNAPSHOT.jar!/org/jahia/defaults/config/spring/applicationcontext-basejahiaconfig.xml]: Invocation of init method failed; nested exception is org.jahia.exceptions.JahiaRuntimeException: Database structure is not initialized
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveReference(BeanDefinitionValueResolver.java:334) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveValueIfNecessary(BeanDefinitionValueResolver.java:108) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyPropertyValues(AbstractAutowireCapableBeanFactory.java:1419) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1160) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:517) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:456) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:293) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:223) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:290) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:195) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.context.support.AbstractApplicationContext.registerBeanPostProcessors(AbstractApplicationContext.java:762) ~[spring-context-3.2.18.RELEASE_OSGI.jar:?]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:467) ~[spring-context-3.2.18.RELEASE_OSGI.jar:?]
	at org.springframework.web.context.ContextLoader.configureAndRefreshWebApplicationContext(ContextLoader.java:410) ~[spring-web-3.2.18.jahia5_OSGI.jar:?]
	at org.springframework.web.context.ContextLoader.initWebApplicationContext(ContextLoader.java:306) [spring-web-3.2.18.jahia5_OSGI.jar:?]
...
Caused by: org.jahia.exceptions.JahiaRuntimeException: Database structure is not initialized
	at org.jahia.settings.SettingsBean.initDatabaseIfNeeded(SettingsBean.java:555) ~[jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.settings.SettingsBean.load(SettingsBean.java:519) ~[jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:569) ~[?:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeCustomInitMethod(AbstractAutowireCapableBeanFactory.java:1640) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1581) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1511) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:519) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:456) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:293) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:223) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:290) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:191) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveReference(BeanDefinitionValueResolver.java:328) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveValueIfNecessary(BeanDefinitionValueResolver.java:108) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyPropertyValues(AbstractAutowireCapableBeanFactory.java:1419) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1160) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:517) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:456) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:293) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:223) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:290) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:191) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveReference(BeanDefinitionValueResolver.java:328) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveValueIfNecessary(BeanDefinitionValueResolver.java:108) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyPropertyValues(AbstractAutowireCapableBeanFactory.java:1419) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1160) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:517) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:456) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:293) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:223) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:290) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:191) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveReference(BeanDefinitionValueResolver.java:328) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveValueIfNecessary(BeanDefinitionValueResolver.java:108) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyPropertyValues(AbstractAutowireCapableBeanFactory.java:1419) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1160) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:517) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:456) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:293) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:223) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:290) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:191) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveReference(BeanDefinitionValueResolver.java:328) ~[spring-beans-3.2.18.jahia2_OSGI.jar:?]
```

That error is no longer present [in this run with the change](https://github.com/Jahia/sitemap/actions/runs/20373804059/job/58546860487) (but the tests fail :/ )

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
