### PR TITLE
ci: Set Docker Compose file param on merge to main

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -58,6 +58,7 @@ jobs:
       jahia_image: jahia/jahia-ee:8.1
       module_id: sitemap
       testrail_project: Sitemap Module
+      docker_compose_file: docker-compose-standalone.yml
       provisioning_manifest: provisioning-manifest-build-8.1.x.yml
       should_use_build_artifacts: true
       artifact_prefix: sitemap-standalone


### PR DESCRIPTION
Fixes https://github.com/Jahia/jahia-private/issues/4598.
### Description
The `docker_compose_file` parameter is missing in the "on merge to main" workflow, causing it [to fail](https://github.com/Jahia/sitemap/actions/runs/20951742104/job/60206838790):
```
   ci.startup.sh == Printing the most important environment variables
   MANIFEST: provisioning-manifest-build-8.1.x.yml
   TESTS_IMAGE: module-tests
   JAHIA_IMAGE: jahia/jahia-ee:8.1
   JAHIA_CLUSTER_ENABLED: false
   NEXUS_USERNAME: jah***ia.com
   DOCKER_COMPOSE_FILE: /opt/actions-runner/_work/sitemap/sitemap/tests/docker-compose.yml
  13 January 2026 -  9:43 [LICENSE] == Check if license exists in env variable (JAHIA_LICENSE) ==
  13 January 2026 -  9:43 == Starting environment ==
  .FileNotFoundError: [Errno 2] No such file or directory: '/opt/actions-runner/_work/sitemap/sitemap/tests/docker-compose.yml'
```

This bug got introduced in https://github.com/Jahia/sitemap/pull/279/changes#diff-52f2d11ee9848eab8314dccf0822c7852a568fed99f06737c13aa214c3ab1fb8.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
