### PR TITLE
fix: fix wrong generateSiteMap job config and call

### DIFF
--- a/.chachalog/iSSBjJRL.md
+++ b/.chachalog/iSSBjJRL.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+sitemap: patch
+---
+
+Fix wrong generateSiteMap job config and call (#301)

--- a/src/main/java/org/jahia/modules/sitemap/config/impl/ConfigServiceImpl.java
+++ b/src/main/java/org/jahia/modules/sitemap/config/impl/ConfigServiceImpl.java
@@ -28,6 +28,7 @@ import org.jahia.modules.sitemap.config.SitemapConfigService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,6 +59,18 @@ public class ConfigServiceImpl implements SitemapConfigService {
                 .filter(propsKey -> !props.get(propsKey).toString().isEmpty())
                 .collect(Collectors.toMap(propsKey -> propsKey, propsKey -> props.get(propsKey).toString(), (a, b) -> b));
         logger.info("Sitemap configuration activated");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Sitemap configuration properties: {}", properties);
+        }
+    }
+
+    @Modified
+    public void modified(Map<String, ?> props) {
+        activate(props);
+        logger.info("Sitemap configuration updated");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Sitemap configuration properties after modification: {}", properties);
+        }
     }
 
     @Deactivate

--- a/src/main/java/org/jahia/modules/sitemap/job/SitemapCreationJob.java
+++ b/src/main/java/org/jahia/modules/sitemap/job/SitemapCreationJob.java
@@ -3,6 +3,7 @@ package org.jahia.modules.sitemap.job;
 import org.apache.commons.lang.StringUtils;
 import org.jahia.api.Constants;
 import org.jahia.modules.sitemap.beans.SitemapEntry;
+import org.jahia.modules.sitemap.config.SitemapConfigService;
 import org.jahia.modules.sitemap.services.SitemapService;
 import org.jahia.modules.sitemap.utils.Utils;
 import org.jahia.osgi.BundleUtils;
@@ -60,7 +61,12 @@ public class SitemapCreationJob extends BackgroundJob {
 
             // Set the job as running (in case of a scheduled job)
             Utils.markSitemapGenerationAsRunning(siteKey);
-            boolean isDebug = jobExecutionContext.getJobDetail().getJobDataMap().getBoolean("debug");
+            // Get debug configuration dynamically from OSGI service (not from cached JobDataMap)
+            SitemapConfigService configService = BundleUtils.getOsgiService(SitemapConfigService.class, null);
+            boolean isDebug = configService != null && configService.isDebug();
+            if (logger.isDebugEnabled()) {
+                logger.debug("Sitemap job execution for site {} - debug mode: {}", siteKey, isDebug);
+            }
             // Set user to be use later by the system sessions.
             JCRSessionFactory.getInstance().setCurrentUser(JahiaUserManagerService.getInstance().lookupRootUser().getJahiaUser());
             JCRTemplate.getInstance().doExecuteWithSystemSession(session -> {

--- a/src/main/java/org/jahia/modules/sitemap/services/impl/SitemapServiceImpl.java
+++ b/src/main/java/org/jahia/modules/sitemap/services/impl/SitemapServiceImpl.java
@@ -105,7 +105,6 @@ public class SitemapServiceImpl implements SitemapService {
     public void scheduleSitemapJob(String siteKey, String repeatInterval) throws SchedulerException {
         deleteSitemapJob(siteKey);
         final JobDetail sitemapJob = BackgroundJob.createJahiaJob("sitemap", SitemapCreationJob.class);
-        sitemapJob.getJobDataMap().put("debug", configService.isDebug());
         sitemapJob.setName(siteKey);
         Trigger trigger = new SimpleTrigger(siteKey, "     sitemapTrigger", REPEAT_INDEFINITELY, getSitemapCacheExpirationInSeconds(repeatInterval) * 1000);
         schedulerService.getScheduler().scheduleJob(sitemapJob, trigger);

--- a/tests/cypress/e2e/config/configureSitemapViaApi.cy.ts
+++ b/tests/cypress/e2e/config/configureSitemapViaApi.cy.ts
@@ -1,6 +1,6 @@
 import { configureSitemap } from '../../utils/configureSitemap'
 import { removeSitemapConfiguration } from '../../utils/removeSitemapConfiguration'
-import { waitForSitemap } from '../../utils/generateSitemap'
+import {generateSitemap, waitForSitemap } from '../../utils/generateSitemap'
 import { switchToBrowsingApolloClient, switchToProcessingApolloClient } from '../../utils/apollo'
 import { enableModule } from '@jahia/cypress'
 import { jahiaProcessingConfig } from '../../utils/serversConfig'
@@ -59,53 +59,18 @@ describe('Testing sitemap configuration via GraphQL API', () => {
                 mutationFile: 'graphql/enabledDebug.graphql',
             })
             waitUntilSyncIsComplete()
+            generateSitemap(siteKey)
             waitForSitemap()
             switchToBrowsingApolloClient()
-
-            // Retry mechanism to ensure OSGI service has taken the configuration into account and fix flakiness of the test
-            const maxRetries = 4
-            const waitTime = 5000 // 5 seconds
-            let retryCount = 0
-
-            const attemptRequest = (): Cypress.Chainable => {
-                return cy.request('en/sites/digitall/sitemap-lang.xml').then((response) => {
-                    const debugExpected = debug === 'true'
-                    const bodyContent = response.body
-
-                    // Debug logging to understand response handling
-                    cy.log(`Response status: ${response.status}`)
-                    cy.log(`Response type: ${typeof bodyContent}`)
-                    cy.log(`Response length: ${bodyContent.length}`)
-                    cy.log(`First 500 chars: ${bodyContent.substring(0, 500)}`)
-
-                    const hasDebugInfo = bodyContent.includes('<!-- nodePath:')
-                    cy.log(`Has debug info: ${hasDebugInfo}, Expected: ${debugExpected}`)
-
-                    const isValid = debugExpected === hasDebugInfo
-
-                    if (!isValid && retryCount < maxRetries - 1) {
-                        retryCount++
-                        cy.log(
-                            `Attempt ${retryCount}: Debug config mismatch detected. Expected debug=${debugExpected}, ` +
-                                `hasDebugInfo=${hasDebugInfo}. Retrying in ${waitTime}ms...`,
-                        )
-                        // In a retry strategy, wait is mandatory...
-                        // eslint-disable-next-line cypress/no-unnecessary-waiting
-                        return cy.wait(waitTime).then(() => attemptRequest())
-                    }
-
-                    // Final validation
-                    if (debugExpected) {
-                        expect(response.body, 'Should contain comment tags in debug').to.contains('<!-- nodePath:')
-                    } else {
-                        expect(response.body, 'Should not contain comment tags in non debug').not.to.contains(
-                            '<!-- nodePath:',
-                        )
-                    }
-                })
-            }
-
-            attemptRequest()
+            cy.request('en/sites/digitall/sitemap-lang.xml').then((response) => {
+                if (debug === 'true') {
+                    expect(response.body, 'Should contain comment tags in debug').to.contains('<!-- nodePath:')
+                } else {
+                    expect(response.body, 'Should not contain comment tags in non debug').not.to.contains(
+                        '<!-- nodePath:',
+                    )
+                }
+            })
         })
     })
 })

--- a/tests/cypress/e2e/config/configureSitemapViaApi.cy.ts
+++ b/tests/cypress/e2e/config/configureSitemapViaApi.cy.ts
@@ -1,6 +1,6 @@
 import { configureSitemap } from '../../utils/configureSitemap'
 import { removeSitemapConfiguration } from '../../utils/removeSitemapConfiguration'
-import {generateSitemap, waitForSitemap } from '../../utils/generateSitemap'
+import { generateSitemap, waitForSitemap } from '../../utils/generateSitemap'
 import { switchToBrowsingApolloClient, switchToProcessingApolloClient } from '../../utils/apollo'
 import { enableModule } from '@jahia/cypress'
 import { jahiaProcessingConfig } from '../../utils/serversConfig'

--- a/tests/cypress/e2e/config/configureSitemapViaApi.cy.ts
+++ b/tests/cypress/e2e/config/configureSitemapViaApi.cy.ts
@@ -61,15 +61,37 @@ describe('Testing sitemap configuration via GraphQL API', () => {
             waitUntilSyncIsComplete()
             waitForSitemap()
             switchToBrowsingApolloClient()
-            cy.request('en/sites/digitall/sitemap-lang.xml').then((response) => {
-                if (debug === 'true') {
-                    expect(response.body, 'Should contain comment tags in debug').to.contains('<!-- nodePath:')
-                } else {
-                    expect(response.body, 'Should not contain comment tags in non debug').not.to.contains(
-                        '<!-- nodePath:',
-                    )
-                }
-            })
+
+            // Retry mechanism to ensure OSGI service has taken the configuration into account and fix flakiness of the test
+            const maxRetries = 4
+            const waitTime = 5000 // 5 seconds
+            let retryCount = 0
+
+            const attemptRequest = (): Cypress.Chainable => {
+                return cy.request('en/sites/digitall/sitemap-lang.xml').then((response) => {
+                    const debugExpected = debug === 'true'
+                    const hasDebugInfo = response.body.includes('<!-- nodePath:')
+                    const isValid = debugExpected === hasDebugInfo
+
+                    if (!isValid && retryCount < maxRetries - 1) {
+                        retryCount++
+                        cy.log(
+                            `Attempt ${retryCount}: Debug config mismatch detected. Expected debug=${debugExpected}, ` +
+                                `hasDebugInfo=${hasDebugInfo}. Retrying in ${waitTime}ms...`,
+                        )
+                        return cy.wait(waitTime).then(() => attemptRequest())
+                    }
+
+                    // Final validation
+                    if (debugExpected) {
+                        expect(response.body, 'Should contain comment tags in debug').to.contains('<!-- nodePath:')
+                    } else {
+                        expect(response.body, 'Should not contain comment tags in non debug').not.to.contains('<!-- nodePath:')
+                    }
+                })
+            }
+
+            attemptRequest()
         })
     })
 })

--- a/tests/cypress/e2e/config/configureSitemapViaApi.cy.ts
+++ b/tests/cypress/e2e/config/configureSitemapViaApi.cy.ts
@@ -79,6 +79,8 @@ describe('Testing sitemap configuration via GraphQL API', () => {
                             `Attempt ${retryCount}: Debug config mismatch detected. Expected debug=${debugExpected}, ` +
                                 `hasDebugInfo=${hasDebugInfo}. Retrying in ${waitTime}ms...`,
                         )
+                        // In a retry strategy, wait is mandatory...
+                        // eslint-disable-next-line cypress/no-unnecessary-waiting
                         return cy.wait(waitTime).then(() => attemptRequest())
                     }
 
@@ -86,7 +88,9 @@ describe('Testing sitemap configuration via GraphQL API', () => {
                     if (debugExpected) {
                         expect(response.body, 'Should contain comment tags in debug').to.contains('<!-- nodePath:')
                     } else {
-                        expect(response.body, 'Should not contain comment tags in non debug').not.to.contains('<!-- nodePath:')
+                        expect(response.body, 'Should not contain comment tags in non debug').not.to.contains(
+                            '<!-- nodePath:',
+                        )
                     }
                 })
             }

--- a/tests/cypress/e2e/config/configureSitemapViaApi.cy.ts
+++ b/tests/cypress/e2e/config/configureSitemapViaApi.cy.ts
@@ -70,7 +70,17 @@ describe('Testing sitemap configuration via GraphQL API', () => {
             const attemptRequest = (): Cypress.Chainable => {
                 return cy.request('en/sites/digitall/sitemap-lang.xml').then((response) => {
                     const debugExpected = debug === 'true'
-                    const hasDebugInfo = response.body.includes('<!-- nodePath:')
+                    const bodyContent = response.body
+
+                    // Debug logging to understand response handling
+                    cy.log(`Response status: ${response.status}`)
+                    cy.log(`Response type: ${typeof bodyContent}`)
+                    cy.log(`Response length: ${bodyContent.length}`)
+                    cy.log(`First 500 chars: ${bodyContent.substring(0, 500)}`)
+
+                    const hasDebugInfo = bodyContent.includes('<!-- nodePath:')
+                    cy.log(`Has debug info: ${hasDebugInfo}, Expected: ${debugExpected}`)
+
                     const isValid = debugExpected === hasDebugInfo
 
                     if (!isValid && retryCount < maxRetries - 1) {

--- a/tests/cypress/e2e/config/configureSitemapViaApi.cy.ts
+++ b/tests/cypress/e2e/config/configureSitemapViaApi.cy.ts
@@ -59,9 +59,8 @@ describe('Testing sitemap configuration via GraphQL API', () => {
                 mutationFile: 'graphql/enabledDebug.graphql',
             })
             waitUntilSyncIsComplete()
-            generateSitemap(siteKey)
-            waitForSitemap()
             switchToBrowsingApolloClient()
+            generateSitemap(siteKey)
             cy.request('en/sites/digitall/sitemap-lang.xml').then((response) => {
                 if (debug === 'true') {
                     expect(response.body, 'Should contain comment tags in debug').to.contains('<!-- nodePath:')


### PR DESCRIPTION
### Description

This pull request addresses issues with the sitemap generation job configuration and improves how debug mode is handled for sitemap jobs. The main changes ensure that debug configuration is now dynamically retrieved from the OSGI service rather than being cached, and the job scheduling logic has been updated accordingly. Additionally, logging and configuration update handling have been enhanced, and the Cypress test suite now correctly invokes sitemap generation.

**Sitemap job configuration and debug mode handling:**

* The sitemap job now retrieves the debug configuration dynamically from the `SitemapConfigService` OSGI service instead of using a cached value from the JobDataMap. This ensures the job always uses the latest configuration. (`src/main/java/org/jahia/modules/sitemap/job/SitemapCreationJob.java`)
* The job scheduling logic in `SitemapServiceImpl` was updated to remove the static debug value from the job data map, further ensuring correct dynamic configuration usage. (`src/main/java/org/jahia/modules/sitemap/services/impl/SitemapServiceImpl.java`)

**Configuration service improvements:**

* Added the `@Modified` method to `ConfigServiceImpl` to properly handle configuration updates and log changes, ensuring that updates to the configuration are reflected immediately. (`src/main/java/org/jahia/modules/sitemap/config/impl/ConfigServiceImpl.java`) [[1]](diffhunk://#diff-432ee0bdc7aefee8d395424196dcf3d2249bf3342246a8269dda0487acec1facR31) [[2]](diffhunk://#diff-432ee0bdc7aefee8d395424196dcf3d2249bf3342246a8269dda0487acec1facR62-R73)

**Testing and documentation:**

* The Cypress test suite was updated to explicitly call `generateSitemap` before checking the sitemap output, ensuring tests reflect the new job invocation flow. (`tests/cypress/e2e/config/configureSitemapViaApi.cy.ts`) [[1]](diffhunk://#diff-f512a7186623c78050ea9400bcb0f2732099915674c484bbd2b1610954a63697L3-R3) [[2]](diffhunk://#diff-f512a7186623c78050ea9400bcb0f2732099915674c484bbd2b1610954a63697L62-R63)
* Changelog entry was added documenting the fix for the wrong sitemap job configuration and invocation. (`.chachalog/iSSBjJRL.md`)